### PR TITLE
Nginx rejects Content-Type without a space before "boundary".

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -318,7 +318,7 @@ public class FileTransfer extends CordovaPlugin {
 
                     // Use a post method.
                     conn.setRequestMethod(httpMethod);
-                    conn.setRequestProperty("Content-Type", "multipart/form-data;boundary=" + BOUNDARY);
+                    conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + BOUNDARY);
 
                     // Set the cookies on the response
                     String cookie = CookieManager.getInstance().getCookie(target);

--- a/src/wp/FileTransfer.cs
+++ b/src/wp/FileTransfer.cs
@@ -285,7 +285,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                     return;
                 }
                 webRequest = (HttpWebRequest)WebRequest.Create(serverUri);
-                webRequest.ContentType = "multipart/form-data;boundary=" + Boundary;
+                webRequest.ContentType = "multipart/form-data; boundary=" + Boundary;
                 webRequest.Method = uploadOptions.Method;
 
                 if (!string.IsNullOrEmpty(uploadOptions.Headers))


### PR DESCRIPTION
I ran into this bug when testing an app on both iOS and Android and using Nginx as a reverse proxy to my application server. The Content-Type produced by the iOS backend is accepted just fine (with the space), but the Content-Type produced by the Android backend is rejected by Nginx as being a malformed HTTP request (a 400). See more discussion here:
http://stackoverflow.com/questions/17990705/phonegap-uploading-file-to-server-using-multipart-form-data
