### PR TITLE
Remove updateBytesRead in read(bytes[] buffer)

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -160,7 +160,7 @@ public class FileTransfer extends CordovaPlugin {
 
         @Override
         public int read(byte[] buffer) throws IOException {
-            return updateBytesRead(super.read(buffer));
+            return super.read(buffer);
         }
 
         @Override


### PR DESCRIPTION
Prevent to increasing bytesRead twice
In SimpleTrackingInputStream.read(buffer), super.read(bytes) will call SimpleTrackingInputStream.read(bytes, 0, bytes.length). Threfore, remove updateBytesRead in read(bytes[] buffer). 
