### PR TITLE
CB-5631: Progress loaded count in Android 

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -159,11 +159,6 @@ public class FileTransfer extends CordovaPlugin {
         }
 
         @Override
-        public int read(byte[] buffer) throws IOException {
-            return updateBytesRead(super.read(buffer));
-        }
-
-        @Override
         public int read(byte[] bytes, int offset, int count) throws IOException {
             return updateBytesRead(super.read(bytes, offset, count));
         }


### PR DESCRIPTION
SimpleTrackingInputStream.getTotalRawBytesRead returns twice the number of bytes actually read.

InputStream.read(byte[] buffer) calls InputStream.read(byte[] bytes, int offset, int count).  As SimpleTrackingInputStream overrides both these methods a call to SimpleTrackingInputStream.read(byte[] buffer) results in a call to SimpleTrackingInputStream.read(byte[] bytes, int offset, int count) - and two calls to SimpleTrackingInputStream.updateBytesRead, so the counter bytesRead gets incremented twice for each read.

This change removes the implementation of SimpleTrackingInputStream.read(byte[] buffer).
