### PR TITLE
Fixed - Xcode erros. CDVFileTransfer.m:304:54: Incompatible operand types ('id' and 'CGPathRef' (aka 'const struct CGPath *'))

### DIFF
--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -297,7 +297,13 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
         return;
     } else {
         // Extract the path part out of a file: URL.
-        NSString* filePath = [source hasPrefix:@"/"] ? [source copy] : [[NSURL URLWithString:source] path];
+        NSString* filePath;
+        if ([target hasPrefix:@"/"]) {
+            filePath = [target copy];
+        } else {
+            filePath = [(NSURL *)[NSURL URLWithString:target] path];
+        }
+        
         if (filePath == nil) {
             // We couldn't find the asset.  Send the appropriate error.
             CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[self createFileTransferError:NOT_FOUND_ERR AndSource:source AndTarget:server]];


### PR DESCRIPTION
Fixed - Xcode erros. CDVFileTransfer.m:304:54: Incompatible operand types ('id' and 'CGPathRef' (aka 'const struct CGPath *'))
