### PR TITLE
FileTransfer did not abort on ios

### DIFF
--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -333,7 +333,7 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
         return;
     }
     CDVFileTransferDelegate* delegate = [self delegateForUploadCommand:command];
-    [NSURLConnection connectionWithRequest:req delegate:delegate];
+    delegate.connection = [NSURLConnection connectionWithRequest:req delegate:delegate];
 
     if (activeTransfers == nil) {
         activeTransfers = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
This fix works for me - don't know much about Objective C but in ["cancelTransfer"-method](https://github.com/bastibeckr/cordova-plugin-file-transfer/blob/58fc57dc9b22f13bd5e33e3b180a0a0f9f6bf428/src/ios/CDVFileTransfer.m#L573-578) the connection-Object was NULL. Hope this helps.
