### PR TITLE
[CB-6202] [WP8] Upload progress needs to be fixed for second file

### DIFF
--- a/src/wp/FileTransfer.cs
+++ b/src/wp/FileTransfer.cs
@@ -765,6 +765,8 @@ namespace WPCordovaClassLib.Cordova.Commands
 
                             byte[] buffer = new byte[4096];
                             int bytesRead = 0;
+                            //sent bytes needs to be reseted before new upload
+                            bytesSent = 0;
                             totalBytesToSend = fileStream.Length;
 
                             requestStream.Write(boundaryBytes, 0, boundaryBytes.Length);


### PR DESCRIPTION
Sent bytes must be reseted before new upload, otherwise "onprogress" event "loaded" value provides sum of uploaded bytes (not just for the current upload, but all of them).
This PR fixes the issue for me, but there is additional work necessary:
- check if this does not break anything
- check if it works for file downloading (I'm not using it myself).

Ref: https://issues.apache.org/jira/browse/CB-6202
