### PR TITLE
CB-8095 Adds support for progress events to upload operation

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -42,14 +42,12 @@ Although in the global scope, they are not available until after the `deviceread
 - Firefox OS**
 - iOS
 - Windows Phone 7 and 8*
-- Windows 8***
-- Windows***
+- Windows 8
+- Windows
 
 \* _Do not support `onprogress` nor `abort()`_
 
 \** _Do not support `onprogress`_
-
-\*** Partial support of `onprogress` for upload method. `onprogress` is called with empty progress event due to Windows limitations_
 
 # FileTransfer
 

--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -106,55 +106,134 @@ exec(win, fail, 'FileTransfer', 'upload',
                 mimeType = storageFile.contentType;
             }
 
-            storageFile.openAsync(Windows.Storage.FileAccessMode.read)
-            .then(function (stream) {
+            // check if download isn't already cancelled
+            var uploadOp = fileTransferOps[uploadId];
+            if (uploadOp && uploadOp.state === FileTransferOperation.CANCELLED) {
+                // Here we should call errorCB with ABORT_ERR error
+                errorCallback(new FTErr(FTErr.ABORT_ERR, nativePathToCordova(filePath), server));
+                return;
+            }
 
-                // check if upload isn't already cancelled
-                var uploadOp = fileTransferOps[uploadId];
-                if (uploadOp && uploadOp.state == FileTransferOperation.CANCELLED) {
-                    // Here we should call errorCB with ABORT_ERR error
-                    errorCallback(new FTErr(FTErr.ABORT_ERR, filePath, server));
-                    return;
+            // setting request headers for uploader
+            var uploader = new Windows.Networking.BackgroundTransfer.BackgroundUploader();
+            for (var header in headers) {
+                if (headers.hasOwnProperty(header)) {
+                    uploader.setRequestHeader(header, headers[header]);
                 }
+            }
 
-                var blob = MSApp.createBlobFromRandomAccessStream(mimeType, stream);
-
-                var formData = new FormData();
-                formData.append(fileKey, blob, fileName);
-                // add params
-                for(var key in params) {
-                    formData.append(key,params[key]);
+            // adding params supplied to request payload
+            var transferParts = [];
+            for (var key in params) {
+                if (params.hasOwnProperty(key)) {
+                    var contentPart = new Windows.Networking.BackgroundTransfer.BackgroundTransferContentPart();
+                    contentPart.setHeader("Content-Disposition", "form-data; name=\"" + key + "\"");
+                    contentPart.setText(params[key]);
+                    transferParts.push(contentPart);
                 }
+            }
 
-                var uploadOperation;
-                try {
-                    // Create XHR promise for uploading data to server
-                    uploadOperation = WinJS.xhr({ type: "POST", url: server, data: formData, headers: headers });
-                    fileTransferOps[uploadId].promise = uploadOperation;
-                } catch (e) {
-                    // it will fail if URL is malformed, so we handle this situation
-                    errorCallback(new FTErr(FTErr.INVALID_URL_ERR, filePath, server, null, null, e));
-                    return;
-                }
+            // Adding file to upload to request payload
+            var fileToUploadPart = new Windows.Networking.BackgroundTransfer.BackgroundTransferContentPart(fileKey, fileName);
+            fileToUploadPart.setFile(storageFile);
+            transferParts.push(fileToUploadPart);
 
-                uploadOperation.then(function (response) {
-                    storageFile.getBasicPropertiesAsync().done(function(basicProperties) {
-                        var ftResult = new FileUploadResult(basicProperties.size, response.status, response.responseText);
-                        successCallback(ftResult);
-                    });
-                }, function(err) {
-                    if ('status' in err) {
-                        errorCallback(new FTErr(FTErr.CONNECTION_ERR, filePath, server, err.status, err.responseText, err));
-                    } else {
-                        errorCallback(new FTErr(FTErr.INVALID_URL_ERR, filePath, server, null, null, err));
+            // create download object. This will throw an exception if URL is malformed
+            var uri = new Windows.Foundation.Uri(server);
+            try {
+                uploader.createUploadAsync(uri, transferParts).then(
+                    function (upload) {
+
+                        // update internal TransferOperation object with newly created promise
+                        var uploadOperation = upload.startAsync();
+                        fileTransferOps[uploadId].promise = uploadOperation;
+
+                        uploadOperation.then(
+                            function (result) {
+                                // Update TransferOperation object with new state, delete promise property
+                                // since it is not actual anymore
+                                var currentUploadOp = fileTransferOps[uploadId];
+                                if (currentUploadOp) {
+                                    currentUploadOp.state = FileTransferOperation.DONE;
+                                    currentUploadOp.promise = null;
+                                }
+
+                                var response = result.getResponseInformation();
+                                // creating a data reader, attached to response stream to get server's response
+                                var reader = new Windows.Storage.Streams.DataReader(result.getResultStreamAt(0));
+                                reader.loadAsync(result.progress.bytesReceived).then(function(size) {
+                                    var responseText = reader.readString(size);
+                                    var ftResult = new FileUploadResult(size, response.statusCode, responseText);
+                                    successCallback(ftResult);
+                                    reader.close();
+                                });
+                            },
+                            function (error) {
+
+                                var source = nativePathToCordova(filePath);
+
+                                // Handle download error here.
+                                // Wrap this routines into promise due to some async methods
+                                var getTransferError = new WinJS.Promise(function(resolve) {
+                                    if (error.message === 'Canceled') {
+                                        // If download was cancelled, message property will be specified
+                                        resolve(new FTErr(FTErr.ABORT_ERR, source, server, null, null, error));
+                                    } else {
+                                        // in the other way, try to get response property
+                                        var response = upload.getResponseInformation();
+                                        if (!response) {
+                                            resolve(new FTErr(FTErr.CONNECTION_ERR, source, server));
+                                        } else {
+                                            var reader = new Windows.Storage.Streams.DataReader(upload.getResultStreamAt(0));
+                                            reader.loadAsync(upload.progress.bytesReceived).then(function (size) {
+                                                var responseText = reader.readString(size);
+                                                resolve(new FTErr(FTErr.FILE_NOT_FOUND_ERR, source, server, response.statusCode, responseText, error));
+                                                reader.close();
+                                            });
+                                        }
+                                    }
+                                });
+
+                                // Update TransferOperation object with new state, delete promise property
+                                // since it is not actual anymore
+                                var currentUploadOp = fileTransferOps[uploadId];
+                                if (currentUploadOp) {
+                                    currentUploadOp.state = FileTransferOperation.CANCELLED;
+                                    currentUploadOp.promise = null;
+                                }
+
+                                // Cleanup, remove incompleted file
+                                getTransferError.then(function(transferError) {
+                                    storageFile.deleteAsync().then(function() {
+                                        errorCallback(transferError);
+                                    });
+                                });
+
+
+                            },
+                            function (evt) {
+
+
+                                var progressEvent = new ProgressEvent('progress', {
+                                    loaded: evt.progress.bytesSent,
+                                    total: evt.progress.totalBytesToSend,
+                                    target: evt.resultFile
+                                });
+                                progressEvent.lengthComputable = true;
+                                successCallback(progressEvent, { keepCallback: true });
+                            }
+                        );
+
+                    },
+                    function (err) {
+                        var errorObj = new FTErr(FTErr.INVALID_URL_ERR);
+                        errorObj.exception = err;
+                        errorCallback(errorObj);
                     }
-                }, function(evt) {
-                    // progress event handler, calls successCallback with empty ProgressEvent
-                    // We can't specify ProgressEvent data here since evt not provides any helpful information
-                    var progressEvent = new ProgressEvent('progress');
-                    successCallback(progressEvent, { keepCallback: true });
-                });
-            });
+                );
+            } catch (e) {
+                errorCallback(new FTErr(FTErr.INVALID_URL_ERR));
+            }
         }, function(err) {
             errorCallback(new FTErr(FTErr.FILE_NOT_FOUND_ERR, server, server, null, null, err));
         });

--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -20,6 +20,8 @@
 */
 
 /*jshint -W030 */
+/*global Windows, WinJS*/
+/*global module, require*/
 
 var FTErr = require('./FileTransferError'),
     ProgressEvent = require('org.apache.cordova.file.ProgressEvent'),
@@ -71,17 +73,17 @@ exec(win, fail, 'FileTransfer', 'upload',
         var fileName = options[3];
         var mimeType = options[4];
         var params = options[5];
-        var trustAllHosts = options[6]; // todo
-        var chunkedMode = options[7]; // todo 
+        // var trustAllHosts = options[6]; // todo
+        // var chunkedMode = options[7]; // todo 
         var headers = options[8] || {};
         var uploadId = options[9];
 
-        if (!filePath || (typeof filePath != 'string')) {
+        if (!filePath || (typeof filePath !== 'string')) {
             errorCallback(new FTErr(FTErr.FILE_NOT_FOUND_ERR,null,server));
             return;
         }
 
-        if (filePath.substr(0, 8) == "file:///") {
+        if (filePath.substr(0, 8) === "file:///") {
             filePath = appData.localFolder.path + filePath.substr(8).split("/").join("\\");
         } else if (filePath.indexOf('ms-appdata:///') === 0) {
             // Handle 'ms-appdata' scheme
@@ -143,7 +145,6 @@ exec(win, fail, 'FileTransfer', 'upload',
             try {
                 uploader.createUploadAsync(uri, transferParts).then(
                     function (upload) {
-
                         // update internal TransferOperation object with newly created promise
                         var uploadOperation = upload.startAsync();
                         fileTransferOps[uploadId].promise = uploadOperation;
@@ -169,7 +170,6 @@ exec(win, fail, 'FileTransfer', 'upload',
                                 });
                             },
                             function (error) {
-
                                 var source = nativePathToCordova(filePath);
 
                                 // Handle download error here.
@@ -208,12 +208,8 @@ exec(win, fail, 'FileTransfer', 'upload',
                                         errorCallback(transferError);
                                     });
                                 });
-
-
                             },
                             function (evt) {
-
-
                                 var progressEvent = new ProgressEvent('progress', {
                                     loaded: evt.progress.bytesSent,
                                     total: evt.progress.totalBytesToSend,
@@ -223,7 +219,6 @@ exec(win, fail, 'FileTransfer', 'upload',
                                 successCallback(progressEvent, { keepCallback: true });
                             }
                         );
-
                     },
                     function (err) {
                         var errorObj = new FTErr(FTErr.INVALID_URL_ERR);
@@ -250,7 +245,7 @@ exec(win, fail, 'FileTransfer', 'upload',
             errorCallback(new FTErr(FTErr.FILE_NOT_FOUND_ERR));
             return;
         }
-        if (target.substr(0, 8) == "file:///") {
+        if (target.substr(0, 8) === "file:///") {
             target = appData.localFolder.path + target.substr(8).split("/").join("\\");
         } else if (target.indexOf('ms-appdata:///') === 0) {
             // Handle 'ms-appdata' scheme
@@ -276,7 +271,7 @@ exec(win, fail, 'FileTransfer', 'upload',
 
                 // check if download isn't already cancelled
                 var downloadOp = fileTransferOps[downloadId];
-                if (downloadOp && downloadOp.state == FileTransferOperation.CANCELLED) {
+                if (downloadOp && downloadOp.state === FileTransferOperation.CANCELLED) {
                     // Here we should call errorCB with ABORT_ERR error
                     errorCallback(new FTErr(FTErr.ABORT_ERR, source, target));
                     return;
@@ -285,7 +280,9 @@ exec(win, fail, 'FileTransfer', 'upload',
                 // if download isn't cancelled, contunue with creating and preparing download operation
                 var downloader = new Windows.Networking.BackgroundTransfer.BackgroundDownloader();
                 for (var header in headers) {
-                    downloader.setRequestHeader(header, headers[header]);
+                    if (header.hasOwnProperty(header)) {
+                        downloader.setRequestHeader(header, headers[header]);
+                    }
                 }
 
                 // create download object. This will throw an exception if URL is malformed

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -19,10 +19,15 @@
 *
 */
 
+/* global exports, cordova */
+/* global describe, it, expect, beforeEach, afterEach, jasmine, pending, spyOn */
+
+/* global FileTransfer, FileTransferError, FileUploadOptions, LocalFileSystem */
+
 exports.defineAutoTests = function () {
 
     // constants
-    var GRACE_TIME_DELTA = 300 // in milliseconds
+    var GRACE_TIME_DELTA = 300; // in milliseconds
     var UNKNOWN_HOST = "http://foobar.apache.org";
     var HEADERS_ECHO = "http://whatheaders.com"; // NOTE: this site is very useful!
 
@@ -34,11 +39,7 @@ exports.defineAutoTests = function () {
 
     // flags
     var isWindows = function() {
-        return (cordova.platformId == "windows") || (navigator.appVersion.indexOf("MSAppHost/1.0") !== -1);
-    };
-
-    var isWP81 = function() {
-        return navigator.appVersion.indexOf("Windows Phone 8.1;") !== -1;
+        return (cordova.platformId === "windows") || (navigator.appVersion.indexOf("MSAppHost/1.0") !== -1);
     };
 
     describe('FileTransferError', function () {
@@ -126,7 +127,7 @@ exports.defineAutoTests = function () {
                 function (fileEntry) {
                     fileEntry.createWriter(function (writer) {
 
-                        writer.onwrite = function (evt) {
+                        writer.onwrite = function () {
                             console.log('created test file \'' + name + '\'');
                             success(fileEntry);
                         };
@@ -202,21 +203,27 @@ exports.defineAutoTests = function () {
         beforeEach(function() {
 
             // ignore the actual implementations of the unexpected callbacks
-            for (callback in unexpectedCallbacks) {
-                spyOn(unexpectedCallbacks, callback);
+            for (var callback in unexpectedCallbacks) {
+                if (unexpectedCallbacks.hasOwnProperty(callback)) {
+                    spyOn(unexpectedCallbacks, callback);
+                }
             }
 
             // but run the implementations of the expected callbacks
             for (callback in expectedCallbacks) {
-                spyOn(expectedCallbacks, callback).and.callThrough();
+                if (expectedCallbacks.hasOwnProperty(callback)) {
+                    spyOn(expectedCallbacks, callback).and.callThrough();
+                }
             }
         });
 
         // at the end, check that none of the unexpected callbacks got called,
         // and act on the expected callbacks
         afterEach(function() {
-            for (callback in unexpectedCallbacks) {
-                expect(unexpectedCallbacks[callback]).not.toHaveBeenCalled();
+            for (var callback in unexpectedCallbacks) {
+                if (unexpectedCallbacks.hasOwnProperty(callback)) {
+                    expect(unexpectedCallbacks[callback]).not.toHaveBeenCalled();
+                }
             }
 
             if (expectedCallbacks.unsupportedOperation.calls.any()) {
@@ -380,7 +387,7 @@ exports.defineAutoTests = function () {
                         var reader = new FileReader();
 
                         reader.onerror = unexpectedCallbacks.fileOperationFail;
-                        reader.onload  = function (e) {
+                        reader.onload  = function () {
                             expect(reader.result).toMatch(/The Apache Software Foundation/);
                             done();
                         };
@@ -607,6 +614,7 @@ exports.defineAutoTests = function () {
                 var uploadOptions;
 
                 var fileName;
+                var fileContents;
                 var localFilePath;
 
                 // helpers
@@ -633,7 +641,7 @@ exports.defineAutoTests = function () {
                     fileName      = 'fileToUpload.txt';
                     fileContents  = 'upload test file';
 
-                    uploadParams        = new Object();
+                    uploadParams        = {};
                     uploadParams.value1 = "test";
                     uploadParams.value2 = "param";
 
@@ -646,7 +654,7 @@ exports.defineAutoTests = function () {
                     var fileWin = function (entry) {
                         localFilePath = entry.toURL();
                         done();
-                    }
+                    };
 
                     // create a file to upload
                     writeFile(root, fileName, fileContents, fileWin);
@@ -665,7 +673,7 @@ exports.defineAutoTests = function () {
 
                         verifyUpload(uploadResult);
 
-                        if (cordova.platformId == 'ios') {
+                        if (cordova.platformId === 'ios') {
                             expect(uploadResult.headers).toBeDefined('Expected headers to be defined.');
                             expect(uploadResult.headers['Content-Type']).toBeDefined('Expected content-type header to be defined.');
                         }
@@ -703,7 +711,7 @@ exports.defineAutoTests = function () {
                         setTimeout(done, GRACE_TIME_DELTA * 2);
                     };
 
-                    var fileWin = function (fileEntry) {
+                    var fileWin = function () {
 
                         startTime = +new Date();
 
@@ -859,7 +867,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     var videoURL = "http://techslides.com/demos/sample-videos/small.mp4";
 
     function clearResults() {
-        results = document.getElementById("info");
+        var results = document.getElementById("info");
         results.innerHTML = '';
     }
 
@@ -870,8 +878,8 @@ exports.defineManualTests = function (contentEl, createActionButton) {
             var ft = new FileTransfer();
             console.log("Starting download");
             ft.download(source, fileSystem.root.toURL() + filename, function (entry) {
-                console.log("Download complete")
-                element.src = urlFn(entry)
+                console.log("Download complete");
+                element.src = urlFn(entry);
                 console.log("Src URL is " + element.src);
                 console.log("Inserting element");
                 document.getElementById("info").appendChild(element);
@@ -879,14 +887,14 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         }
         console.log("Requesting filesystem");
         clearResults();
-        requestFileSystem(TEMPORARY, 0, function (fileSystem) {
+        window.requestFileSystem(LocalFileSystem.TEMPORARY, 0, function (fileSystem) {
             console.log("Checking for existing file");
-            if (directory != undefined) {
+            if (directory !== undefined) {
                 console.log("Checking for existing directory.");
                 fileSystem.root.getDirectory(directory, {}, function (dirEntry) {
                     dirEntry.removeRecursively(function () {
                         download(fileSystem);
-                    }, function (e) { console.log("ERROR: dirEntry.removeRecursively") });
+                    }, function () { console.log("ERROR: dirEntry.removeRecursively"); });
                 }, function () {
                     download(fileSystem);
                 });
@@ -895,12 +903,12 @@ exports.defineManualTests = function (contentEl, createActionButton) {
                     console.log("Removing existing file");
                     entry.remove(function () {
                         download(fileSystem);
-                    }, function (e) { console.log("ERROR: entry.remove"); });
+                    }, function () { console.log("ERROR: entry.remove"); });
                 }, function () {
                     download(fileSystem);
                 });
             }
-        }, function (e) { console.log("ERROR: requestFileSystem"); });
+        }, function () { console.log("ERROR: requestFileSystem"); });
     }
 
     /******************************************************************************/
@@ -923,11 +931,11 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     }, 'cdv_image');
 
     createActionButton('Download and display img (native)', function () {
-        downloadImg(imageURL, function (entry) { return entry.toNativeURL(); }, new Image);
+        downloadImg(imageURL, function (entry) { return entry.toNativeURL(); }, new Image());
     }, 'native_image');
 
     createActionButton('Download to a non-existent dir (should work)', function () {
-        downloadImg(imageURL, function (entry) { return entry.toURL(); }, new Image, '/nonExistentDirTest/');
+        downloadImg(imageURL, function (entry) { return entry.toURL(); }, new Image(), '/nonExistentDirTest/');
     }, 'non-existent_dir');
 
     createActionButton('Download and play video (cdvfile)', function () {
@@ -939,6 +947,6 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton('Download and play video (native)', function () {
         var videoElement = document.createElement('video');
         videoElement.controls = "controls";
-        downloadImg(videoURL, function (entry) { return entry.toNativeURL(); }, videoElement)
+        downloadImg(videoURL, function (entry) { return entry.toNativeURL(); }, videoElement);
     }, 'native_video');
 };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -659,12 +659,6 @@ exports.defineAutoTests = function () {
 
                 it("filetransfer.spec.18 should be able to upload a file", function (done) {
 
-                    // according to spec "onprogress" method isn't supported on WP
-                    if (isWP81()) {
-                        pending();
-                        return;
-                    }
-
                     var fileURL = SERVER + '/upload';
 
                     var uploadWin = function (uploadResult) {
@@ -684,12 +678,6 @@ exports.defineAutoTests = function () {
                 });
 
                 it("filetransfer.spec.19 should be able to upload a file with http basic auth", function (done) {
-
-                    // according to spec "onprogress" method doesn't supported on WP
-                    if (isWP81()) {
-                        pending();
-                        return;
-                    }
 
                     var fileURL = SERVER_WITH_CREDENTIALS + "/upload_basic_auth";
 


### PR DESCRIPTION
This fixes [CB-8095](https://issues.apache.org/jira/browse/CB-8095)

On windows FileTrasfer doesn't support progress events for upload operation properly since internal implementation uses XHR which doesn't provide all information, necessary to fire correct progress events.

This PR replaces XHR with `BackgroundUploader` class which itself supports progress notification in more convenient way and can provide all necessary data for progress events for FileTransfer.