### PR TITLE
CB-8721 - Better header parse with custom WSSE syntax

### DIFF
--- a/src/wp/FileTransfer.cs
+++ b/src/wp/FileTransfer.cs
@@ -311,27 +311,7 @@ namespace WPCordovaClassLib.Cordova.Commands
         {
             try
             {
-                Dictionary<string, string> result = new Dictionary<string, string>();
-
-                string temp = jsonHeaders.StartsWith("{") ? jsonHeaders.Substring(1) : jsonHeaders;
-                temp = temp.EndsWith("}") ? temp.Substring(0, temp.Length - 1) : temp;
-
-                string[] strHeaders = temp.Split(',');
-                for (int n = 0; n < strHeaders.Length; n++)
-                {
-                    // we need to use indexOf in order to WP7 compatible
-                    int splitIndex = strHeaders[n].IndexOf(':');
-                    if (splitIndex > 0)
-                    {
-                        string[] split = new string[2];
-                        split[0] = strHeaders[n].Substring(0, splitIndex);
-                        split[1] = strHeaders[n].Substring(splitIndex + 1);
-
-                        split[0] = JSON.JsonHelper.Deserialize<string>(split[0]);
-                        split[1] = JSON.JsonHelper.Deserialize<string>(split[1]);
-                        result[split[0]] = split[1];
-                    }
-                }
+                Dictionary<string, string> result = JSON.JsonHelper.Deserialize<Dictionary<string, string>>(jsonHeaders);
                 return result;
             }
             catch (Exception)


### PR DESCRIPTION
Changed the FileTransfer.cs#parseHeaders function to work with the changes of the https://github.com/apache/cordova-wp8/pull/62 pull request.

The problem is that, with WSSE headers with a VALUE like this:

```
UsernameToken Username="foo@bar.net", PasswordDigest="ZTQXXXXXXXXXXXXXXXXXXXXXXXXXXXX0NTJlMGE2M2I0NGJiYWM4NA==", Nonce="XXXXXXXXXXXXXXXXXXXXXXXXXXXXA==", Created="2014-10-11T18:48:07.232Z"
```

The current version of the function, will return null because of a bad parse by DataContractJsonSerializer. The pull request I mentioned suggests change DataContractJsonSerializer by Newtonsoft.Json for a better serialize and performance.