### PR TITLE
CB-5059 Add a CookieManager abstraction for pluggable webviews.

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -213,6 +213,34 @@ public class FileTransfer extends CordovaPlugin {
         }
     }
 
+    private String getCookies(final String target) {
+        boolean gotCookie = false;
+        String cookie = null;
+        Class webViewClass = webView.getClass();
+        try {
+            Method gcmMethod = webViewClass.getMethod("getCookieManager");
+            Class iccmClass  = gcmMethod.getReturnType();
+            Method gcMethod  = iccmClass.getMethod("getCookie");
+
+            cookie = (String)gcMethod.invoke(
+                        iccmClass.cast(
+                            gcmMethod.invoke(webView)
+                        ), target);
+
+            gotCookie = true;
+        } catch (NoSuchMethodException e) {
+        } catch (IllegalAccessException e) {
+        } catch (InvocationTargetException e) {
+        } catch (ClassCastException e) {
+        }
+
+        if (!gotCookie) {
+            cookie = CookieManager.getInstance().getCookie(target);
+        }
+
+        return cookie;
+    }
+
     /**
      * Uploads the specified file to the server URL provided using an HTTP multipart request.
      * @param source        Full path of the file on the file system
@@ -316,7 +344,8 @@ public class FileTransfer extends CordovaPlugin {
                     conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + BOUNDARY);
 
                     // Set the cookies on the response
-                    String cookie = CookieManager.getInstance().getCookie(target);
+                    String cookie = getCookies(target);
+
                     if (cookie != null) {
                         conn.setRequestProperty("Cookie", cookie);
                     }
@@ -781,7 +810,8 @@ public class FileTransfer extends CordovaPlugin {
                         connection.setRequestMethod("GET");
         
                         // TODO: Make OkHttp use this CookieManager by default.
-                        String cookie = CookieManager.getInstance().getCookie(sourceUri.toString());
+                        String cookie = getCookies(sourceUri.toString());
+
                         if(cookie != null)
                         {
                             connection.setRequestProperty("cookie", cookie);


### PR DESCRIPTION
This allows FileTransfer to correctly use webview cookies regardless of which webview engine is in use.

/cc @agrieve @infil00p

Requires apache/cordova-android#151

Refs #8 
Refs MobileChromeApps/mobile-chrome-apps#464
Refs MobileChromeApps/cordova-crosswalk-engine#16
Refs crosswalk-project/crosswalk-cordova-android#38