### PR TITLE
CB-8407 Fix downloading of ms-appdata:/// urls on Windows

### DIFF
--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -26,6 +26,7 @@
 var FTErr = require('./FileTransferError'),
     ProgressEvent = require('org.apache.cordova.file.ProgressEvent'),
     FileUploadResult = require('org.apache.cordova.file.FileUploadResult'),
+    FileProxy = require('org.apache.cordova.file.FileProxy'),
     FileEntry = require('org.apache.cordova.file.FileEntry');
 
 var appData = Windows.Storage.ApplicationData.current;
@@ -313,7 +314,9 @@ exec(win, fail, 'FileTransfer', 'upload',
                         .replace(appData.temporaryFolder.path, 'ms-appdata:///temp')
                         .replace('\\', '/');
 
-                    successCallback(new FileEntry(storageFile.name, storageFile.path, null, nativeURI));
+                    // Passing null as error callback here because downloaded file should exist in any case
+                    // otherwise the error callback will be hit during file creation in another place
+                    FileProxy.resolveLocalFileSystemURI(successCallback, null, [nativeURI]);
                 }, function(error) {
 
                     var getTransferError = new WinJS.Promise(function (resolve) {

--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -237,7 +237,7 @@ exec(win, fail, 'FileTransfer', 'upload',
     // [source, target, trustAllHosts, id, headers]
     download:function(successCallback, errorCallback, options) {
         var source = options[0];
-        var target = cordovaPathToNative(options[1]);
+        var target = options[1];
         var downloadId = options[3];
         var headers = options[4] || {};
 
@@ -252,7 +252,7 @@ exec(win, fail, 'FileTransfer', 'upload',
             target = target.replace('ms-appdata:///local', appData.localFolder.path)
                            .replace('ms-appdata:///temp', appData.temporaryFolder.path);
         }
-        target = cordovaPathToNative(target); // again?
+        target = cordovaPathToNative(target);
 
         var path = target.substr(0, target.lastIndexOf("\\"));
         var fileName = target.substr(target.lastIndexOf("\\") + 1);


### PR DESCRIPTION
JIRA issue [CB-8407](https://issues.apache.org/jira/browse/CB-8407)

download() in file-transfer plugin expects path instead of internal URL on windows
This bug seems to be introduced with these changes to cordova-plugin-file: https://github.com/apache/cordova-plugin-file/commit/bcbeae24cd24583b790da95e0e076492eb16cd4f
All tests for download method of file-transfer plugin now fail on windows with following message:
```
Exception calling native with command :: FileTransfer :: download ::exception=WinRTError: The parameter is incorrect.
```