### PR TITLE
Fix NoSuchMethodException looking up cookies.

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -220,7 +220,7 @@ public class FileTransfer extends CordovaPlugin {
         try {
             Method gcmMethod = webViewClass.getMethod("getCookieManager");
             Class iccmClass  = gcmMethod.getReturnType();
-            Method gcMethod  = iccmClass.getMethod("getCookie");
+            Method gcMethod  = iccmClass.getMethod("getCookie", String.class);
 
             cookie = (String)gcMethod.invoke(
                         iccmClass.cast(


### PR DESCRIPTION
This was causing the FileTransfer plugin to always use the fallback android.webkit.CookieManager.