### PR TITLE
CB-6313 [wp8]: Extra boundary in upload

### DIFF
--- a/src/wp/FileTransfer.cs
+++ b/src/wp/FileTransfer.cs
@@ -730,7 +730,6 @@ namespace WPCordovaClassLib.Cordova.Commands
                             byte[] formItemBytes = System.Text.Encoding.UTF8.GetBytes(formItem);
                             requestStream.Write(formItemBytes, 0, formItemBytes.Length);
                         }
-                        requestStream.Write(boundaryBytes, 0, boundaryBytes.Length);
                     }
                     using (IsolatedStorageFile isoFile = IsolatedStorageFile.GetUserStoreForApplication())
                     {


### PR DESCRIPTION
When performing an upload on Windows Phone, an extra boundary is
included after any parameters, and before the file contents. This causes
some servers (such as express/multiparty on node.js) to fail to handle
the request properly.

This commit removes the extraneous boundary.

Fixes https://issues.apache.org/jira/browse/CB-6313