### PR TITLE
CB-8931 Replace all slashes in windows path

### DIFF
--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -312,7 +312,7 @@ exec(win, fail, 'FileTransfer', 'upload',
 
                     var nativeURI = storageFile.path.replace(appData.localFolder.path, 'ms-appdata:///local')
                         .replace(appData.temporaryFolder.path, 'ms-appdata:///temp')
-                        .replace('\\', '/');
+                        .replace(/\\/g, '/');
 
                     // Passing null as error callback here because downloaded file should exist in any case
                     // otherwise the error callback will be hit during file creation in another place


### PR DESCRIPTION
Using a windows path raises an error. This fixes it by replacing all slashes in windows path instead of just the first one. 