### PR TITLE
CB-8431 File Transfer tests crash on Android Lolipop

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -980,7 +980,7 @@ public class FileTransfer extends CordovaPlugin {
                             try{
                                    context.connection.disconnect();
                             } catch (Exception e) {                              
-                                   Log.e(LOG_TAG, "Catch workaround for fatal exception", e);
+                                   Log.e(LOG_TAG, "CB-8431 Catch workaround for fatal exception", e);
                             }
                         }
                     }

--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -977,7 +977,11 @@ public class FileTransfer extends CordovaPlugin {
                         context.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, error));
                         context.aborted = true;
                         if (context.connection != null) {
-                            context.connection.disconnect();
+                            try{
+                                   context.connection.disconnect();
+                            } catch (Exception e) {                              
+                                   Log.e(LOG_TAG, "Catch workaround for fatal exception", e);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Tested in a Ionic Application on my Nexus 5 (Android 5.1): without the added try/catch, the application sometimes crash with a fatal error.