### PR TITLE
CB-8951 Fixed crash related to headers parsing on wp8

### DIFF
--- a/src/wp/FileTransfer.cs
+++ b/src/wp/FileTransfer.cs
@@ -370,9 +370,12 @@ namespace WPCordovaClassLib.Cordova.Commands
                 if (!string.IsNullOrEmpty(uploadOptions.Headers))
                 {
                     Dictionary<string, string> headers = parseHeaders(uploadOptions.Headers);
-                    foreach (string key in headers.Keys)
+                    if (headers != null)
                     {
-                        webRequest.Headers[key] = headers[key];
+                        foreach (string key in headers.Keys)
+                        {
+                            webRequest.Headers[key] = headers[key];
+                        }
                     }
                 }
 
@@ -566,9 +569,12 @@ namespace WPCordovaClassLib.Cordova.Commands
                 if (!string.IsNullOrEmpty(downloadOptions.Headers))
                 {
                     Dictionary<string, string> headers = parseHeaders(downloadOptions.Headers);
-                    foreach (string key in headers.Keys)
+                    if (headers != null)
                     {
-                        webRequest.Headers[key] = headers[key];
+                        foreach (string key in headers.Keys)
+                        {
+                            webRequest.Headers[key] = headers[key];
+                        }
                     }
                 }
 


### PR DESCRIPTION
This is a quick fix for a crash described here: https://issues.apache.org/jira/browse/CB-8951

More in-depth approach can be found here:
https://github.com/apache/cordova-plugin-file-transfer/pull/72
but it is being delayed until wp8@4.0.0 release