### PR TITLE
Remove use of CookieManager

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -219,7 +219,7 @@ public class FileTransfer extends CordovaPlugin {
         try {
             Method gcmMethod = webViewClass.getMethod("getCookieManager");
             Class iccmClass  = gcmMethod.getReturnType();
-            Method gcMethod  = iccmClass.getMethod("getCookie");
+            Method gcMethod  = iccmClass.getMethod("getCookie", String.class);
 
             cookie = (String)gcMethod.invoke(
                         iccmClass.cast(

--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -214,28 +214,22 @@ public class FileTransfer extends CordovaPlugin {
     }
 
     private String getCookies(final String target) {
-        boolean gotCookie = false;
         String cookie = null;
         Class webViewClass = webView.getClass();
         try {
             Method gcmMethod = webViewClass.getMethod("getCookieManager");
             Class iccmClass  = gcmMethod.getReturnType();
-            Method gcMethod  = iccmClass.getMethod("getCookie", String.class);
+            Method gcMethod  = iccmClass.getMethod("getCookie");
 
             cookie = (String)gcMethod.invoke(
                         iccmClass.cast(
                             gcmMethod.invoke(webView)
                         ), target);
 
-            gotCookie = true;
         } catch (NoSuchMethodException e) {
         } catch (IllegalAccessException e) {
         } catch (InvocationTargetException e) {
         } catch (ClassCastException e) {
-        }
-
-        if (!gotCookie) {
-            cookie = CookieManager.getInstance().getCookie(target);
         }
 
         return cookie;


### PR DESCRIPTION
This causes an unhandled exception when used with Crosswalk on Api 16. Newer api versions seem to work fine. With the direction heading towards pluggable webviews everything should funnel through the CordovaWebView interface and be handled by the implementation.

As an aside, CordovaWebView has a getCookieManager() method, so I'm not sure why the reflection is needed, but I left it in place because I don't know the code well enough.

For reference, here is the exception that I'm referring to. Note that it doesn't hit XWalk classes at all, which makes it appear that Crosswalk does not have any opportunity to intercept.

06-10 15:28:39.922    2081-2126/com.mb.android W/dalvikvm﹕ JNI WARNING: JNI method called with exception pending
06-10 15:28:39.922    2081-2126/com.mb.android W/dalvikvm﹕ in Landroid/webkit/CookieManagerClassic;.nativeGetCookie:(Ljava/lang/String;Z)Ljava/lang/String; (GetStringUTFChars)
06-10 15:28:39.922    2081-2126/com.mb.android W/dalvikvm﹕ Pending exception is:
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ java.lang.IllegalStateException: Call CookieSyncManager::createInstance() or create a webview before using this class
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ at android.webkit.JniUtil.checkInitialized(JniUtil.java:44)
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ at android.webkit.JniUtil.getDatabaseDirectory(JniUtil.java:65)
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ at android.webkit.CookieManagerClassic.nativeGetCookie(Native Method)
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ at android.webkit.CookieManagerClassic.getCookie(CookieManagerClassic.java:91)
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ at android.webkit.CookieManagerClassic.getCookie(CookieManagerClassic.java:78)
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ at org.apache.cordova.filetransfer.FileTransfer.getCookies(FileTransfer.java:240)
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ at org.apache.cordova.filetransfer.FileTransfer.access$200(FileTransfer.java:70)
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ at org.apache.cordova.filetransfer.FileTransfer$4.run(FileTransfer.java:819)
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1076)
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:569)
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ at java.lang.Thread.run(Thread.java:856)
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ "pool-1-thread-2" prio=5 tid=27 NATIVE
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ | group="main" sCount=0 dsCount=0 obj=0xb3a84848 self=0xb91a2140
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ | sysTid=2126 nice=0 sched=0/0 cgrp=[fopen-error:2] handle=-1189253184
06-10 15:28:39.922    2081-2126/com.mb.android I/dalvikvm﹕ | schedstat=( 0 0 0 ) utm=9 stm=1 core=0