### PR TITLE
Fix/wp8 browser cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ __Parameters__:
   - __chunkedMode__: Whether to upload the data in chunked streaming mode. Defaults to `true`. (Boolean)
   - __headers__: A map of header name/header values. Use an array to specify more than one value.  On iOS, FireOS, and Android, if a header named Content-Type is present, multipart form data will NOT be used. (Object)
   - __httpMethod__: The HTTP method to use e.g. POST or PUT.  Defaults to `POST`. (DOMString)
+  - __useBrowserHttp__: Use webview to do HTTP requests, using its cookies.  Enables cross-site requests which need cookies on wp8.  Supported on wp8.  Defaults to `false`. (Boolean)
 
 - __trustAllHosts__: Optional parameter, defaults to `false`. If set to `true`, it accepts all security certificates. This is useful since Android rejects self-signed security certificates. Not recommended for production use. Supported on Android and iOS. _(boolean)_
 
@@ -197,7 +198,7 @@ __Parameters__:
 
 - __trustAllHosts__: Optional parameter, defaults to `false`. If set to `true`, it accepts all security certificates. This is useful because Android rejects self-signed security certificates. Not recommended for production use. Supported on Android and iOS. _(boolean)_
 
-- __options__: Optional parameters, currently only supports headers (such as Authorization (Basic Authentication), etc).
+- __options__: Optional parameters, currently only supports `headers` (such as Authorization (Basic Authentication), etc) and `useBrowserHttp` (on wp8 to enable cross-site cookies).
 
 ### Example
 
@@ -229,6 +230,8 @@ __Parameters__:
 ### WP8 Quirks
 
 - Download requests is being cached by native implementation. To avoid caching, pass `if-Modified-Since` header to download method.
+
+- By default, cookies for a request can only be copied from the currently loaded page of the webview.  Use the `useBrowserHttp` flag to work around this issue.
 
 ## abort
 

--- a/src/amazon/FileTransfer.java
+++ b/src/amazon/FileTransfer.java
@@ -226,6 +226,12 @@ public class FileTransfer extends CordovaPlugin {
      * args[3] fileName      File name to be used on server
      * args[4] mimeType      Describes file content type
      * args[5] params        key:value pairs of user-defined parameters
+     * args[6] trustAllHosts Accept all security certificates
+     * args[7] chunkedMode   Whether to upload the data in chunked streaming mode
+     * args[8] useBrowserHttp   Use webview for HTTP request (unimplemented)
+     * args[9] headers       Headers to send with the request
+     * args[10] objectId     Unique id
+     * args[11] httpMethod   HTTP method for the request
      * @return FileUploadResult containing result of upload request
      */
     private void upload(final String source, final String target, JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -239,10 +245,11 @@ public class FileTransfer extends CordovaPlugin {
         final boolean trustEveryone = args.optBoolean(6);
         // Always use chunked mode unless set to false as per API
         final boolean chunkedMode = args.optBoolean(7) || args.isNull(7);
+        final boolean useBrowserHttp = args.optBoolean(8);
         // Look for headers on the params map for backwards compatibility with older Cordova versions.
-        final JSONObject headers = args.optJSONObject(8) == null ? params.optJSONObject("headers") : args.optJSONObject(8);
-        final String objectId = args.getString(9);
-        final String httpMethod = getArgument(args, 10, "POST");
+        final JSONObject headers = args.optJSONObject(9) == null ? params.optJSONObject("headers") : args.optJSONObject(9);
+        final String objectId = args.getString(10);
+        final String httpMethod = getArgument(args, 11, "POST");
         
         final CordovaResourceApi resourceApi = webView.getResourceApi();
 
@@ -252,6 +259,7 @@ public class FileTransfer extends CordovaPlugin {
         Log.d(LOG_TAG, "params: " + params);
         Log.d(LOG_TAG, "trustEveryone: " + trustEveryone);
         Log.d(LOG_TAG, "chunkedMode: " + chunkedMode);
+        Log.d(LOG_TAG, "useBrowserHttp: " + useBrowserHttp);
         Log.d(LOG_TAG, "headers: " + headers);
         Log.d(LOG_TAG, "objectId: " + objectId);
         Log.d(LOG_TAG, "httpMethod: " + httpMethod);
@@ -671,8 +679,9 @@ public class FileTransfer extends CordovaPlugin {
         final CordovaResourceApi resourceApi = webView.getResourceApi();
 
         final boolean trustEveryone = args.optBoolean(2);
-        final String objectId = args.getString(3);
-        final JSONObject headers = args.optJSONObject(4);
+        final boolean useBrowserHttp = args.optBoolean(3);
+        final String objectId = args.getString(4);
+        final JSONObject headers = args.optJSONObject(5);
         
         final Uri sourceUri = resourceApi.remapUri(Uri.parse(source));
         // Accept a path or a URI for the source.

--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -252,6 +252,12 @@ public class FileTransfer extends CordovaPlugin {
      * args[3] fileName      File name to be used on server
      * args[4] mimeType      Describes file content type
      * args[5] params        key:value pairs of user-defined parameters
+     * args[6] trustAllHosts Accept all security certificates
+     * args[7] chunkedMode   Whether to upload the data in chunked streaming mode
+     * args[8] useBrowserHttp   Use webview for HTTP request (unimplemented)
+     * args[9] headers       Headers to send with the request
+     * args[10] objectId     Unique id
+     * args[11] httpMethod   HTTP method for the request
      * @return FileUploadResult containing result of upload request
      */
     private void upload(final String source, final String target, JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -265,10 +271,12 @@ public class FileTransfer extends CordovaPlugin {
         final boolean trustEveryone = args.optBoolean(6);
         // Always use chunked mode unless set to false as per API
         final boolean chunkedMode = args.optBoolean(7) || args.isNull(7);
+        final boolean useBrowserHttp = args.optBoolean(8);
+
         // Look for headers on the params map for backwards compatibility with older Cordova versions.
-        final JSONObject headers = args.optJSONObject(8) == null ? params.optJSONObject("headers") : args.optJSONObject(8);
-        final String objectId = args.getString(9);
-        final String httpMethod = getArgument(args, 10, "POST");
+        final JSONObject headers = args.optJSONObject(9) == null ? params.optJSONObject("headers") : args.optJSONObject(9);
+        final String objectId = args.getString(10);
+        final String httpMethod = getArgument(args, 11, "POST");
         
         final CordovaResourceApi resourceApi = webView.getResourceApi();
 
@@ -278,6 +286,7 @@ public class FileTransfer extends CordovaPlugin {
         Log.d(LOG_TAG, "params: " + params);
         Log.d(LOG_TAG, "trustEveryone: " + trustEveryone);
         Log.d(LOG_TAG, "chunkedMode: " + chunkedMode);
+        Log.d(LOG_TAG, "useBrowserHttp: " + useBrowserHttp);
         Log.d(LOG_TAG, "headers: " + headers);
         Log.d(LOG_TAG, "objectId: " + objectId);
         Log.d(LOG_TAG, "httpMethod: " + httpMethod);
@@ -711,8 +720,9 @@ public class FileTransfer extends CordovaPlugin {
         final CordovaResourceApi resourceApi = webView.getResourceApi();
 
         final boolean trustEveryone = args.optBoolean(2);
-        final String objectId = args.getString(3);
-        final JSONObject headers = args.optJSONObject(4);
+        final boolean useBrowserHttp = args.optBoolean(3);
+        final String objectId = args.getString(4);
+        final JSONObject headers = args.optJSONObject(5);
         
         final Uri sourceUri = resourceApi.remapUri(Uri.parse(source));
         // Accept a path or a URI for the source.

--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -137,7 +137,7 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
 
 - (NSURLRequest*)requestForUploadCommand:(CDVInvokedUrlCommand*)command fileData:(NSData*)fileData
 {
-    // arguments order from js: [filePath, server, fileKey, fileName, mimeType, params, debug, chunkedMode]
+    // arguments order from js: [filePath, server, fileKey, fileName, mimeType, params, debug, chunkedMode, useBrowserHttp]
     // however, params is a JavaScript object and during marshalling is put into the options dict,
     // thus debug and chunkedMode are the 6th and 7th arguments
     NSString* target = [command argumentAtIndex:0];
@@ -148,11 +148,13 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     NSDictionary* options = [command argumentAtIndex:5 withDefault:nil];
     //    BOOL trustAllHosts = [[command argumentAtIndex:6 withDefault:[NSNumber numberWithBool:YES]] boolValue]; // allow self-signed certs
     BOOL chunkedMode = [[command argumentAtIndex:7 withDefault:[NSNumber numberWithBool:YES]] boolValue];
-    NSDictionary* headers = [command argumentAtIndex:8 withDefault:nil];
+    BOOL useBrowserHttp = [[command argumentAtIndex:8 withDefault:[NSNumber numberWithBool:NO]] boolValue];
+
+    NSDictionary* headers = [command argumentAtIndex:9 withDefault:nil];
     // Allow alternative http method, default to POST. JS side checks
     // for allowed methods, currently PUT or POST (forces POST for
     // unrecognised values)
-    NSString* httpMethod = [command argumentAtIndex:10 withDefault:@"POST"];
+    NSString* httpMethod = [command argumentAtIndex:11 withDefault:@"POST"];
     CDVPluginResult* result = nil;
     CDVFileTransferError errorCode = 0;
 
@@ -390,8 +392,9 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     NSString* source = [command argumentAtIndex:0];
     NSString* target = [command argumentAtIndex:1];
     BOOL trustAllHosts = [[command argumentAtIndex:2 withDefault:[NSNumber numberWithBool:NO]] boolValue]; // allow self-signed certs
-    NSString* objectId = [command argumentAtIndex:3];
-    NSDictionary* headers = [command argumentAtIndex:4 withDefault:nil];
+    BOOL useBrowserHttp = [[command argumentAtIndex:3 withDefault:[NSNumber numberWithBool:NO]] boolValue];
+    NSString* objectId = [command argumentAtIndex:4];
+    NSDictionary* headers = [command argumentAtIndex:5 withDefault:nil];
 
     CDVPluginResult* result = nil;
     CDVFileTransferError errorCode = 0;

--- a/src/ubuntu/file-transfer.cpp
+++ b/src/ubuntu/file-transfer.cpp
@@ -37,7 +37,7 @@ static void SetHeaders(QNetworkRequest &request, const QVariantMap &headers) {
     }
 }
 
-void FileTransfer::download(int scId, int ecId, const QString& url, const QString &target, bool /*trustAllHost*/, int id, const QVariantMap &headers) {
+void FileTransfer::download(int scId, int ecId, const QString& url, const QString &target, bool /*trustAllHost*/, bool /*useBrowserHttp*/, int id, const QVariantMap &headers) {
     QSharedPointer<FileTransferRequest> request(new FileTransferRequest(_manager, scId, ecId, id, this));
 
     assert(_id2request.find(id) == _id2request.end());
@@ -58,7 +58,7 @@ void FileTransfer::download(int scId, int ecId, const QString& url, const QStrin
 }
 
 void FileTransfer::upload(int scId, int ecId, const QString &fileURI, const QString& url, const QString& fileKey, const QString& fileName, const QString& mimeType,
-                          const QVariantMap & params, bool /*trustAllHosts*/, bool /*chunkedMode*/, const QVariantMap &headers, int id, const QString &/*httpMethod*/) {
+                          const QVariantMap & params, bool /*trustAllHosts*/, bool /*chunkedMode*/, bool /*useBrowserHttp*/, const QVariantMap &headers, int id, const QString &/*httpMethod*/) {
     QSharedPointer<FileTransferRequest> request(new FileTransferRequest(_manager, scId, ecId, id, this));
 
     assert(_id2request.find(id) == _id2request.end());

--- a/src/ubuntu/file-transfer.h
+++ b/src/ubuntu/file-transfer.h
@@ -90,9 +90,9 @@ public:
 
 public slots:
     void abort(int scId, int ecId, int id);
-    void download(int scId, int ecId, const QString& url, const QString &target, bool /*trustAllHost*/, int id, const QVariantMap &/*headers*/);
+    void download(int scId, int ecId, const QString& url, const QString &target, bool /*trustAllHost*/, bool /*useBrowserHttp*/, int id, const QVariantMap &/*headers*/);
     void upload(int scId, int ecId, const QString &filePath, const QString& url, const QString& fileKey, const QString& fileName, const QString& mimeType,
-                const QVariantMap & params, bool /*trustAllHosts*/, bool /*chunkedMode*/, const QVariantMap &headers, int id, const QString &httpMethod);
+                const QVariantMap & params, bool /*trustAllHosts*/, bool /*chunkedMode*/, bool /*useBrowserHttp*/, const QVariantMap &headers, int id, const QString &httpMethod);
 
 private:
     QNetworkAccessManager _manager;

--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -65,7 +65,7 @@ module.exports = {
 
 /*
 exec(win, fail, 'FileTransfer', 'upload', 
-[filePath, server, fileKey, fileName, mimeType, params, trustAllHosts, chunkedMode, headers, this._id, httpMethod]);
+[filePath, server, fileKey, fileName, mimeType, params, trustAllHosts, chunkedMode, useBrowserHttp, headers, this._id, httpMethod]);
 */
     upload:function(successCallback, errorCallback, options) {
         var filePath = options[0];
@@ -75,9 +75,10 @@ exec(win, fail, 'FileTransfer', 'upload',
         var mimeType = options[4];
         var params = options[5];
         // var trustAllHosts = options[6]; // todo
-        // var chunkedMode = options[7]; // todo 
-        var headers = options[8] || {};
-        var uploadId = options[9];
+        // var chunkedMode = options[7]; // todo
+        // var useBrowserHttp = options[8]; // todo
+        var headers = options[9] || {};
+        var uploadId = options[10];
 
         if (!filePath || (typeof filePath !== 'string')) {
             errorCallback(new FTErr(FTErr.FILE_NOT_FOUND_ERR,null,server));
@@ -242,12 +243,12 @@ exec(win, fail, 'FileTransfer', 'upload',
         });
     },
 
-    // [source, target, trustAllHosts, id, headers]
+    // [source, target, trustAllHosts, useBrowserHttp, id, headers]
     download:function(successCallback, errorCallback, options) {
         var source = options[0];
         var target = options[1];
-        var downloadId = options[3];
-        var headers = options[4] || {};
+        var downloadId = options[4];
+        var headers = options[5] || {};
 
         if (!target) {
             errorCallback(new FTErr(FTErr.FILE_NOT_FOUND_ERR));

--- a/src/wp/FileTransfer.cs
+++ b/src/wp/FileTransfer.cs
@@ -68,6 +68,8 @@ namespace WPCordovaClassLib.Cordova.Commands
             /// Additional options
             public string Params { get; set; }
             public string Method { get; set; }
+            /// Use webview browser to perform HTTP requests
+            public bool UseBrowserHttp { get; set; }
 
             public TransferOptions()
             {
@@ -333,7 +335,7 @@ namespace WPCordovaClassLib.Cordova.Commands
         /// sends a file to a server
         /// </summary>
         /// <param name="options">Upload options</param>
-        /// exec(win, fail, 'FileTransfer', 'upload', [filePath, server, fileKey, fileName, mimeType, params, trustAllHosts, chunkedMode, headers, this._id, httpMethod]);
+        /// exec(win, fail, 'FileTransfer', 'upload', [filePath, server, fileKey, fileName, mimeType, params, trustAllHosts, chunkedMode, useBrowserHttp, headers, this._id, httpMethod]);
         public void upload(string options)
         {
             options = options.Replace("{}", ""); // empty objects screw up the Deserializer
@@ -363,15 +365,19 @@ namespace WPCordovaClassLib.Cordova.Commands
                     bool.TryParse(args[7], out doChunked);
                     uploadOptions.ChunkedMode = doChunked;
 
+                    bool useBrowserHttp = false;
+                    bool.TryParse(args[8], out useBrowserHttp);
+                    uploadOptions.UseBrowserHttp = useBrowserHttp;
+
                     //8 : Headers
                     //9 : id
                     //10: method
 
-                    uploadOptions.Headers = args[8];
-                    uploadOptions.Id = args[9];
-                    uploadOptions.Method = args[10];
+                    uploadOptions.Headers = args[9];
+                    uploadOptions.Id = args[10];
+                    uploadOptions.Method = args[11];
 
-                    uploadOptions.CallbackId = callbackId = args[11];
+                    uploadOptions.CallbackId = callbackId = args[12];
                 }
                 catch (Exception)
                 {
@@ -463,7 +469,7 @@ namespace WPCordovaClassLib.Cordova.Commands
 
             try
             {
-                // source, target, trustAllHosts, this._id, headers
+                // source, target, trustAllHosts, useBrowserHttp, this._id, headers
                 string[] optionStrings = JSON.JsonHelper.Deserialize<string[]>(options);
 
                 downloadOptions = new TransferOptions();
@@ -474,9 +480,13 @@ namespace WPCordovaClassLib.Cordova.Commands
                 bool.TryParse(optionStrings[2],out trustAll);
                 downloadOptions.TrustAllHosts = trustAll;
 
-                downloadOptions.Id = optionStrings[3];
-                downloadOptions.Headers = optionStrings[4];
-                downloadOptions.CallbackId = callbackId = optionStrings[5];
+                bool useBrowserHttp = false;
+                bool.TryParse(optionStrings[3],out useBrowserHttp);
+                downloadOptions.UseBrowserHttp = useBrowserHttp;
+
+                downloadOptions.Id = optionStrings[4];
+                downloadOptions.Headers = optionStrings[5];
+                downloadOptions.CallbackId = callbackId = optionStrings[6];
             }
             catch (Exception)
             {

--- a/src/wp/FileTransfer.cs
+++ b/src/wp/FileTransfer.cs
@@ -594,6 +594,8 @@ namespace WPCordovaClassLib.Cordova.Commands
                 }
                 else
                 {
+                    Uri serverUri = new Uri(downloadOptions.Url);
+
                     // otherwise it is web-bound, we will actually download it
                     //Debug.WriteLine("Creating WebRequest for url : " + downloadOptions.Url);
                     if (downloadOptions.UseBrowserHttp)
@@ -601,11 +603,11 @@ namespace WPCordovaClassLib.Cordova.Commands
                         PropertyInfo browserHttp = typeof(System.Net.Browser.WebRequestCreator).GetProperty("BrowserHttp");
                         var requestFactory = browserHttp.GetValue(this.browser, null) as IWebRequestCreate;
 
-                        webRequest = (HttpWebRequest)requestFactory.Create(new Uri(downloadOptions.Url));
+                        webRequest = (HttpWebRequest)requestFactory.Create(serverUri);
                     }
                     else
                     {
-                        webRequest = (HttpWebRequest)WebRequest.Create(downloadOptions.Url);
+                        webRequest = (HttpWebRequest)WebRequest.Create(serverUri);
                     }
                 }
             }

--- a/src/wp/FileTransfer.cs
+++ b/src/wp/FileTransfer.cs
@@ -386,16 +386,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                     return;
                 }
 
-                Uri serverUri;
-                try
-                {
-                    serverUri = new Uri(uploadOptions.Server);
-                }
-                catch (Exception)
-                {
-                    DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, new FileTransferError(InvalidUrlError, uploadOptions.Server, null, 0)));
-                    return;
-                }
+                Uri serverUri = new Uri(uploadOptions.Server);
 
                 if (uploadOptions.UseBrowserHttp)
                 {
@@ -445,9 +436,19 @@ namespace WPCordovaClassLib.Cordova.Commands
 
                 webRequest.BeginGetRequestStream(uploadCallback, reqState);
             }
-            catch (Exception /*ex*/)
+            catch (Exception ex)
             {
-                DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR, new FileTransferError(ConnectionError)),callbackId);
+                // These can be thrown by the Uri constructor
+                if (ex is UriFormatException || ex is NotSupportedException || ex is ArgumentNullException)
+                {
+                    DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR,
+                                          new FileTransferError(InvalidUrlError, uploadOptions.Server, null, 0)));
+                }
+                else
+                {
+                    DispatchCommandResult(new PluginResult(PluginResult.Status.ERROR,
+                                          new FileTransferError(ConnectionError)),callbackId);
+                }
             }
         }
 

--- a/www/FileTransfer.js
+++ b/www/FileTransfer.js
@@ -106,6 +106,7 @@ FileTransfer.prototype.upload = function(filePath, server, successCallback, erro
     var mimeType = null;
     var params = null;
     var chunkedMode = true;
+    var useBrowserHttp = false;
     var headers = null;
     var httpMethod = null;
     var basicAuthHeader = getBasicAuthHeader(server);
@@ -130,6 +131,9 @@ FileTransfer.prototype.upload = function(filePath, server, successCallback, erro
         }
         if (options.chunkedMode !== null || typeof options.chunkedMode != "undefined") {
             chunkedMode = options.chunkedMode;
+        }
+        if (options.useBrowserHttp !== null || typeof options.useBrowserHttp != "undefined") {
+            useBrowserHttp = options.useBrowserHttp;
         }
         if (options.params) {
             params = options.params;
@@ -159,7 +163,7 @@ FileTransfer.prototype.upload = function(filePath, server, successCallback, erro
             successCallback && successCallback(result);
         }
     };
-    exec(win, fail, 'FileTransfer', 'upload', [filePath, server, fileKey, fileName, mimeType, params, trustAllHosts, chunkedMode, headers, this._id, httpMethod]);
+    exec(win, fail, 'FileTransfer', 'upload', [filePath, server, fileKey, fileName, mimeType, params, trustAllHosts, chunkedMode, useBrowserHttp, headers, this._id, httpMethod]);
 };
 
 /**
@@ -174,6 +178,7 @@ FileTransfer.prototype.upload = function(filePath, server, successCallback, erro
 FileTransfer.prototype.download = function(source, target, successCallback, errorCallback, trustAllHosts, options) {
     argscheck.checkArgs('ssFF*', 'FileTransfer.download', arguments);
     var self = this;
+    var useBrowserHttp = false;
 
     var basicAuthHeader = getBasicAuthHeader(source);
     if (basicAuthHeader) {
@@ -187,6 +192,10 @@ FileTransfer.prototype.download = function(source, target, successCallback, erro
     var headers = null;
     if (options) {
         headers = options.headers || null;
+
+        if (options.useBrowserHttp !== null || typeof options.useBrowserHttp != "undefined") {
+            useBrowserHttp = options.useBrowserHttp;
+        }
     }
 
     if (cordova.platformId === "windowsphone" && headers) {
@@ -221,7 +230,7 @@ FileTransfer.prototype.download = function(source, target, successCallback, erro
         errorCallback(error);
     };
 
-    exec(win, fail, 'FileTransfer', 'download', [source, target, trustAllHosts, this._id, headers]);
+    exec(win, fail, 'FileTransfer', 'download', [source, target, trustAllHosts, useBrowserHttp, this._id, headers]);
 };
 
 /**


### PR DESCRIPTION
[wp8] Make it possible to use the webview's cookiestore to do HTTP requests

On the wp8 platform, cookies used to be always copied from the webview when performing a request. However, only the cookies for the currently loaded URL could be copied. This made it impossible to pass cookies cross-origin.

This commit introduces a flag `useBrowserHttp` which when `false` keeps the same behavior.  When `true`, it creates the WebRequest through a different factory method, reusing the cookies of the webview.

Using this option comes at a price though: it makes it impossible to add cookies manually by setting headers and it can't perform GET requests with headers set.  Therefore this functionality is put behind a flag.

Because we had to change the API between the JS and native code to add the flag, this commit also includes platform changes.  Code was tested on ios, android and wp8 platforms.

Co-Authored-By: Leroy van Engelen leroy.van.engelen@mendix.com
