### PR TITLE
README :: remove duplicate httpMethod option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ __Parameters__:
   - __params__: A set of optional key/value pairs to pass in the HTTP request. (Object)
   - __chunkedMode__: Whether to upload the data in chunked streaming mode. Defaults to `true`. (Boolean)
   - __headers__: A map of header name/header values. Use an array to specify more than one value.  On iOS, FireOS, and Android, if a header named Content-Type is present, multipart form data will NOT be used. (Object)
-  - __httpMethod__: The HTTP method to use e.g. POST or PUT.  Defaults to `POST`. (DOMString)
 
 - __trustAllHosts__: Optional parameter, defaults to `false`. If set to `true`, it accepts all security certificates. This is useful since Android rejects self-signed security certificates. Not recommended for production use. Supported on Android and iOS. _(boolean)_
 


### PR DESCRIPTION
The `httpMethod` option was duplicated as an upload option in
[04f088b6c906e0b74bf3610005787b90aa548b9e](https://github.com/apache/cordova-plugin-file-transfer/commit/04f088b6c906e0b74bf3610005787b90aa548b9e)