### PR TITLE
CB-9493 Fix file paths in file-transfer manual tests

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -966,11 +966,11 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         file_transfer_tests;
 
     createActionButton('Download and display img (cdvfile)', function () {
-        downloadImg(imageURL, function (entry) { return entry.toURL(); }, new Image());
+        downloadImg(imageURL, function (entry) { return entry.toInternalURL(); }, new Image());
     }, 'cdv_image');
 
     createActionButton('Download and display img (native)', function () {
-        downloadImg(imageURL, function (entry) { return entry.toNativeURL(); }, new Image());
+        downloadImg(imageURL, function (entry) { return entry.toURL(); }, new Image());
     }, 'native_image');
 
     createActionButton('Download to a non-existent dir (should work)', function () {
@@ -980,12 +980,12 @@ exports.defineManualTests = function (contentEl, createActionButton) {
     createActionButton('Download and play video (cdvfile)', function () {
         var videoElement = document.createElement('video');
         videoElement.controls = "controls";
-        downloadImg(videoURL, function (entry) { return entry.toURL(); }, videoElement);
+        downloadImg(videoURL, function (entry) { return entry.toInternalURL(); }, videoElement);
     }, 'cdv_video');
 
     createActionButton('Download and play video (native)', function () {
         var videoElement = document.createElement('video');
         videoElement.controls = "controls";
-        downloadImg(videoURL, function (entry) { return entry.toNativeURL(); }, videoElement);
+        downloadImg(videoURL, function (entry) { return entry.toURL(); }, videoElement);
     }, 'native_video');
 };


### PR DESCRIPTION
Also changes `toNativeURL` -> `toURL` because of deprecation.

[Jira issue](https://issues.apache.org/jira/browse/CB-9493)