### PR TITLE
Added note about iOS9 and Xcode (7 and higher) quirks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ A `FileUploadResult` object is passed to the success callback of the
 ### iOS Quirks
 
 - Does not support `responseCode` or `bytesSent`.
-- If you are using iOS9 or have upgraded to Xcode7 or higher, then App Transport Security may prevent you from connecting to your desired server. Use cordova-plugin-transport-security to temporarily bypass for development purposes.
+- If you are using iOS9 and Xcode7, then App Transport Security may prevent you from connecting to your desired server. ATS will eventually be handled by the whitelist plugin -- for now, use cordova-plugin-transport-security to temporarily bypass ATS for development purposes.
 
 ### Browser Quirks
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ A `FileUploadResult` object is passed to the success callback of the
 ### iOS Quirks
 
 - Does not support `responseCode` or `bytesSent`.
+- If you are using iOS9 or have upgraded to Xcode7 or higher, then App Transport Security may prevent you from connecting to your desired server. Use cordova-plugin-transport-security to temporarily bypass for development purposes.
 
 ### Browser Quirks
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ A `FileUploadResult` object is passed to the success callback of the
 ### iOS Quirks
 
 - Does not support `responseCode` or `bytesSent`.
-- If you are using iOS9 and Xcode7, then App Transport Security may prevent you from connecting to your desired server. ATS will eventually be handled by the whitelist plugin -- for now, use cordova-plugin-transport-security to temporarily bypass ATS for development purposes.
+- If you are using iOS9 and Xcode7, then App Transport Security (ATS) may prevent you from connecting to your desired server. ATS will eventually be handled by the whitelist plugin -- for now, use cordova-plugin-transport-security to temporarily bypass ATS for development purposes.
 
 ### Browser Quirks
 


### PR DESCRIPTION
I spent many hours identifying this issue and propose modifying the README file with a helpful pointer (to save the time of others). The problem and solution were not obvious and is not anywhere on StackOverflow. In a number of scenarios, the filetransfer error callback was not triggered and my app failed silently -- in scenarios where the error was not silent, the returned error code was 3 (connection error). This is because Xcode7 (and higher) and iOS9 enforce an App Transport Security protocol that requires the file transfer connection to be secure (connect via https). This constraint can be bypassed (for development purposes) by using the following plugin: cordova-plugin-transport-security (https://www.npmjs.com/package/cordova-plugin-transport-security). 