### PR TITLE
CB-51 API: FileTransfer - Support PUT Method

### DIFF
--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -78,6 +78,7 @@ exec(win, fail, 'FileTransfer', 'upload',
         // var chunkedMode = options[7]; // todo 
         var headers = options[8] || {};
         var uploadId = options[9];
+        var httpMethod = options[10];
 
         if (!filePath || (typeof filePath !== 'string')) {
             errorCallback(new FTErr(FTErr.FILE_NOT_FOUND_ERR,null,server));
@@ -122,6 +123,7 @@ exec(win, fail, 'FileTransfer', 'upload',
 
             // setting request headers for uploader
             var uploader = new Windows.Networking.BackgroundTransfer.BackgroundUploader();
+            uploader.method = httpMethod;
             for (var header in headers) {
                 if (headers.hasOwnProperty(header)) {
                     uploader.setRequestHeader(header, headers[header]);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -895,6 +895,33 @@ exports.defineAutoTests = function () {
                         transfer.upload(localPath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptions);
                     }, unsupported, 'File', '_getLocalFilesystemPath', [internalFilePath]);
                 }, UPLOAD_TIMEOUT);
+
+                it("filetransfer.spec.31 should be able to upload a file using PUT method", function (done) {
+
+                    var fileURL = SERVER + '/upload';
+
+                    var uploadWin = function (uploadResult) {
+
+                        verifyUpload(uploadResult);
+
+                        if (cordova.platformId === 'ios') {
+                            expect(uploadResult.headers).toBeDefined('Expected headers to be defined.');
+                            expect(uploadResult.headers['Content-Type']).toBeDefined('Expected content-type header to be defined.');
+                        }
+
+                        done();
+                    };
+
+                    var uploadOptionsPut        = new FileUploadOptions();
+                    uploadOptionsPut.fileKey    = "file";
+                    uploadOptionsPut.fileName   = fileName;
+                    uploadOptionsPut.mimeType   = "text/plain";
+                    uploadOptionsPut.params     = uploadParams;
+                    uploadOptionsPut.httpMethod = "PUT";
+
+                    // NOTE: removing uploadOptions cause Android to timeout
+                    transfer.upload(localFilePath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptionsPut);
+                }, UPLOAD_TIMEOUT);
             });
         });
     });


### PR DESCRIPTION
Adds a test for upload via PUT method
Adds support for Windows platform

[Jira issue](https://issues.apache.org/jira/browse/CB-51)