### PR TITLE
CB-6928 Wrong behaviour transferring cacheable content

### DIFF
--- a/src/ios/CDVFileTransfer.h
+++ b/src/ios/CDVFileTransfer.h
@@ -25,7 +25,8 @@ enum CDVFileTransferError {
     FILE_NOT_FOUND_ERR = 1,
     INVALID_URL_ERR = 2,
     CONNECTION_ERR = 3,
-    CONNECTION_ABORTED = 4
+    CONNECTION_ABORTED = 4,
+    NOT_MODIFIED = 5
 };
 typedef int CDVFileTransferError;
 

--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -592,7 +592,8 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self.filePlugin makeEntryForURL:self.targetURL]];
         } else {
             downloadResponse = [[NSString alloc] initWithData:self.responseData encoding:NSUTF8StringEncoding];
-            CDVFileTransferError errorCode = self.responseCode == 404 ? FILE_NOT_FOUND_ERR : CONNECTION_ERR;
+            CDVFileTransferError errorCode = self.responseCode == 404 ? FILE_NOT_FOUND_ERR
+                : (self.responseCode == 304 ? NOT_MODIFIED : CONNECTION_ERR);
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[command createFileTransferError:errorCode AndSource:source AndTarget:target AndHttpStatus:self.responseCode AndBody:downloadResponse]];
         }
     }

--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -60,6 +60,7 @@ FileTransferOperation.PENDING = 0;
 FileTransferOperation.DONE = 1;
 FileTransferOperation.CANCELLED = 2;
 
+var HTTP_E_STATUS_NOT_MODIFIED = -2145844944;
 
 module.exports = {
 
@@ -339,6 +340,8 @@ exec(win, fail, 'FileTransfer', 'upload',
                         // message property will be specified
                         if (error.message === 'Canceled') {
                             resolve(new FTErr(FTErr.ABORT_ERR, source, target, null, null, error));
+                        } else if (error && error.number === HTTP_E_STATUS_NOT_MODIFIED) {
+                            resolve(new FTErr(FTErr.NOT_MODIFIED_ERR, source, target, 304, null, error));
                         } else {
                             // in the other way, try to get response property
                             var response = download.getResponseInformation();

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -503,7 +503,7 @@ exports.defineAutoTests = function () {
                         expect(error.http_status).toBe(404);
 
                         // wp8 does not make difference between 404 and unknown host
-                        if (isWp8) {
+                        if (isWP8) {
                             expect(error.code).toBe(FileTransferError.CONNECTION_ERR);
                         } else {
                             expect(error.code).toBe(FileTransferError.FILE_NOT_FOUND_ERR);
@@ -650,6 +650,30 @@ exports.defineAutoTests = function () {
                         transfer.download(fileURL, localPath, downloadWin, unexpectedCallbacks.httpFail);
                     }, unsupported, 'File', '_getLocalFilesystemPath', [internalFilePath]);
                 });
+
+                it('filetransfer.spec.31 should properly handle 304', function (done) {
+
+                    if(isWP8) {
+                        pending();
+                        return;
+                    }
+
+                    var imageURL = "http://apache.org/images/feather-small.gif";
+                    var lastModified = new Date();
+
+                    var downloadFail = function (error) {
+                        expect(error.http_status).toBe(304);
+                        expect(error.code).toBe(FileTransferError.NOT_MODIFIED_ERR);
+                        done();
+                    };
+
+                    transfer.download(imageURL, localFilePath, unexpectedCallbacks.httpWin, downloadFail, null,
+                        {
+                            headers: {
+                                'If-Modified-Since': lastModified.toUTCString()
+                            }
+                        });
+                }, DOWNLOAD_TIMEOUT);
             });
 
             describe('upload', function() {


### PR DESCRIPTION
Adds support of 304 handling for iOS, Windows and adds a corresponding test.

[Jira issue](https://issues.apache.org/jira/browse/CB-6928) 