### PR TITLE
CB-9969 Filetransfer upload error deletes original file

### DIFF
--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -631,7 +631,9 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
         delegate.backgroundTaskID = UIBackgroundTaskInvalid;
     }
 
-    [self removeTargetFile];
+    if (self.direction == CDV_TRANSFER_DOWNLOAD) {
+        [self removeTargetFile];
+    }
 }
 
 - (void)cancelTransferWithError:(NSURLConnection*)connection errorMessage:(NSString*)errorMessage

--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -230,11 +230,9 @@ exec(win, fail, 'FileTransfer', 'upload',
                                 currentUploadOp.promise = null;
                             }
 
-                            // Cleanup, remove incompleted file
+                            // Report the upload error back
                             getTransferError.then(function(transferError) {
-                                storageFile.deleteAsync().then(function() {
-                                    errorCallback(transferError);
-                                });
+                                errorCallback(transferError);
                             });
                         },
                         function (evt) {


### PR DESCRIPTION
Adds a corresponding test and fixes for iOS and Windows.

[Jira issue](https://issues.apache.org/jira/browse/CB-9969)

Also fixes `filetransfer.spec.9`, which used an incorrect path in the `root.getFile` call.