### PR TITLE
CB-10044 FileTransfer plug in can upload parts of a file to implement resumablejs

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -256,7 +256,7 @@ public class FileTransfer extends CordovaPlugin {
         } catch (ClassCastException e) {
         }
 
-        if (!gotCookie) {
+        if (!gotCookie && CookieManager.getInstance() != null) {
             cookie = CookieManager.getInstance().getCookie(target);
         }
 

--- a/src/ios/CDVFileTransfer.h
+++ b/src/ios/CDVFileTransfer.h
@@ -25,7 +25,8 @@ enum CDVFileTransferError {
     FILE_NOT_FOUND_ERR = 1,
     INVALID_URL_ERR = 2,
     CONNECTION_ERR = 3,
-    CONNECTION_ABORTED = 4
+    CONNECTION_ABORTED = 4,
+    NOT_MODIFIED = 5
 };
 typedef int CDVFileTransferError;
 

--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -273,21 +273,11 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
         
         if (multipartFormUpload) {
             [postBodyBeforeFile appendData:chunkData];
-            //[postBodyBeforeFile appendData:fileData];
             [postBodyBeforeFile appendData:postBodyAfterFile];
             [req setHTTPBody:postBodyBeforeFile];
         } else {
             [req setHTTPBody:chunkData];
-            //[req setHTTPBody:fileData];
         }
-        
-        // if (multipartFormUpload) {
-        //     [postBodyBeforeFile appendData:fileData];
-        //     [postBodyBeforeFile appendData:postBodyAfterFile];
-        //     [req setHTTPBody:postBodyBeforeFile];
-        // } else {
-        //     [req setHTTPBody:fileData];
-        // }
     }
     return req;
 }

--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -592,7 +592,8 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[self.filePlugin makeEntryForURL:self.targetURL]];
         } else {
             downloadResponse = [[NSString alloc] initWithData:self.responseData encoding:NSUTF8StringEncoding];
-            CDVFileTransferError errorCode = self.responseCode == 404 ? FILE_NOT_FOUND_ERR : CONNECTION_ERR;
+            CDVFileTransferError errorCode = self.responseCode == 404 ? FILE_NOT_FOUND_ERR
+                : (self.responseCode == 304 ? NOT_MODIFIED : CONNECTION_ERR);
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:[command createFileTransferError:errorCode AndSource:source AndTarget:target AndHttpStatus:self.responseCode AndBody:downloadResponse]];
         }
     }

--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -78,6 +78,7 @@ exec(win, fail, 'FileTransfer', 'upload',
         // var chunkedMode = options[7]; // todo 
         var headers = options[8] || {};
         var uploadId = options[9];
+        var httpMethod = options[10];
 
         if (!filePath || (typeof filePath !== 'string')) {
             errorCallback(new FTErr(FTErr.FILE_NOT_FOUND_ERR,null,server));
@@ -122,6 +123,7 @@ exec(win, fail, 'FileTransfer', 'upload',
 
             // setting request headers for uploader
             var uploader = new Windows.Networking.BackgroundTransfer.BackgroundUploader();
+            uploader.method = httpMethod;
             for (var header in headers) {
                 if (headers.hasOwnProperty(header)) {
                     uploader.setRequestHeader(header, headers[header]);

--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -60,6 +60,7 @@ FileTransferOperation.PENDING = 0;
 FileTransferOperation.DONE = 1;
 FileTransferOperation.CANCELLED = 2;
 
+var HTTP_E_STATUS_NOT_MODIFIED = -2145844944;
 
 module.exports = {
 
@@ -339,6 +340,8 @@ exec(win, fail, 'FileTransfer', 'upload',
                         // message property will be specified
                         if (error.message === 'Canceled') {
                             resolve(new FTErr(FTErr.ABORT_ERR, source, target, null, null, error));
+                        } else if (error && error.number === HTTP_E_STATUS_NOT_MODIFIED) {
+                            resolve(new FTErr(FTErr.NOT_MODIFIED_ERR, source, target, 304, null, error));
                         } else {
                             // in the other way, try to get response property
                             var response = download.getResponseInformation();

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -946,6 +946,25 @@ exports.defineAutoTests = function () {
                     // NOTE: removing uploadOptions cause Android to timeout
                     transfer.upload(localFilePath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptionsPut);
                 }, UPLOAD_TIMEOUT);
+                it("filetransfer.spec.32 should be able to upload a part of a file (first 5 bytes)", function (done) {
+
+                    var fileURL = SERVER + '/upload';
+
+                    var uploadWin = function (uploadResult) {
+
+                        verifyUpload(uploadResult);
+
+                        if (cordova.platformId === 'ios') {
+                            expect(uploadResult.headers).toBeDefined('Expected headers to be defined.');
+                            expect(uploadResult.headers['Content-Type']).toBeDefined('Expected content-type header to be defined.');
+                        }
+
+                        done();
+                    };
+
+                    // NOTE: removing uploadOptions cause Android to timeout
+                    transfer.upload(localFilePath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptions,true,0,5);
+                }, UPLOAD_TIMEOUT);
             });
         });
     });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -895,6 +895,33 @@ exports.defineAutoTests = function () {
                         transfer.upload(localPath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptions);
                     }, unsupported, 'File', '_getLocalFilesystemPath', [internalFilePath]);
                 }, UPLOAD_TIMEOUT);
+
+                it("filetransfer.spec.31 should be able to upload a file using PUT method", function (done) {
+
+                    var fileURL = SERVER + '/upload';
+
+                    var uploadWin = function (uploadResult) {
+
+                        verifyUpload(uploadResult);
+
+                        if (cordova.platformId === 'ios') {
+                            expect(uploadResult.headers).toBeDefined('Expected headers to be defined.');
+                            expect(uploadResult.headers['Content-Type']).toBeDefined('Expected content-type header to be defined.');
+                        }
+
+                        done();
+                    };
+
+                    var uploadOptionsPut        = new FileUploadOptions();
+                    uploadOptionsPut.fileKey    = "file";
+                    uploadOptionsPut.fileName   = fileName;
+                    uploadOptionsPut.mimeType   = "text/plain";
+                    uploadOptionsPut.params     = uploadParams;
+                    uploadOptionsPut.httpMethod = "PUT";
+
+                    // NOTE: removing uploadOptions cause Android to timeout
+                    transfer.upload(localFilePath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptionsPut);
+                }, UPLOAD_TIMEOUT);
             });
         });
     });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -45,11 +45,8 @@ exports.defineAutoTests = function () {
     // flags
     var isWindows = cordova.platformId === 'windows8' || cordova.platformId === 'windows';
     var isWP8 = cordova.platformId === 'windowsphone';
-    var isIOS = cordova.platformId === 'ios';
-
     var isBrowser = cordova.platformId === 'browser';
     var isIE = isBrowser && navigator.userAgent.indexOf('Trident') >= 0;
-    var isWp8 = cordova.platformId === "windowsphone";
 
     describe('FileTransferError', function () {
 
@@ -177,9 +174,8 @@ exports.defineAutoTests = function () {
                 // In IE, when lengthComputable === false, event.total somehow is equal to 2^64
                 if (isIE) {
                     expect(event.total).toBe(Math.pow(2, 64));
-                } else if (isIOS) {
-                    expect(event.total).toBe(-1);
                 } else {
+                    // iOS returns -1, and other platforms return 0
                     expect(event.total).toBeLessThan(1);
                 }
             }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -503,7 +503,7 @@ exports.defineAutoTests = function () {
                         expect(error.http_status).toBe(404);
 
                         // wp8 does not make difference between 404 and unknown host
-                        if (isWp8) {
+                        if (isWP8) {
                             expect(error.code).toBe(FileTransferError.CONNECTION_ERR);
                         } else {
                             expect(error.code).toBe(FileTransferError.FILE_NOT_FOUND_ERR);
@@ -650,6 +650,30 @@ exports.defineAutoTests = function () {
                         transfer.download(fileURL, localPath, downloadWin, unexpectedCallbacks.httpFail);
                     }, unsupported, 'File', '_getLocalFilesystemPath', [internalFilePath]);
                 });
+
+                it('filetransfer.spec.31 should properly handle 304', function (done) {
+
+                    if(isWP8) {
+                        pending();
+                        return;
+                    }
+
+                    var imageURL = "http://apache.org/images/feather-small.gif";
+                    var lastModified = new Date();
+
+                    var downloadFail = function (error) {
+                        expect(error.http_status).toBe(304);
+                        expect(error.code).toBe(FileTransferError.NOT_MODIFIED_ERR);
+                        done();
+                    };
+
+                    transfer.download(imageURL, localFilePath, unexpectedCallbacks.httpWin, downloadFail, null,
+                        {
+                            headers: {
+                                'If-Modified-Since': lastModified.toUTCString()
+                            }
+                        });
+                }, DOWNLOAD_TIMEOUT);
             });
 
             describe('upload', function() {


### PR DESCRIPTION
By sending the startByte and endByte to the FileTransfer plugin we are able to upload parts of a file therefore we can integrate this with ResumableJS
