### PR TITLE
CB-9600 FileUploadOptions params not posted on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ __Parameters__:
   - __fileName__: The file name to use when saving the file on the server.  Defaults to `image.jpg`. (DOMString)
   - __httpMethod__: The HTTP method to use - either `PUT` or `POST`. Defaults to `POST`. (DOMString)
   - __mimeType__: The mime type of the data to upload.  Defaults to `image/jpeg`. (DOMString)
-  - __params__: A set of optional key/value pairs to pass in the HTTP request. (Object)
+  - __params__: A set of optional key/value pairs to pass in the HTTP request. (Object, key/value - DOMString)
   - __chunkedMode__: Whether to upload the data in chunked streaming mode. Defaults to `true`. (Boolean)
   - __headers__: A map of header name/header values. Use an array to specify more than one value.  On iOS, FireOS, and Android, if a header named Content-Type is present, multipart form data will NOT be used. (Object)
 


### PR DESCRIPTION
Documents supported params key/value type

[Jira issue](https://issues.apache.org/jira/browse/CB-9600)