### PR TITLE
Allow custom fileKey in base64 multipart form element in Windows upload

### DIFF
--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -232,7 +232,7 @@ exec(win, fail, 'FileTransfer', 'upload',
                 }
 
                 var multipartFile = LINE_START + BOUNDARY + LINE_END;
-                multipartFile += "Content-Disposition: form-data; name=\"file\";";
+                multipartFile += "Content-Disposition: form-data; name=\"" + fileKey +"\";";
                 multipartFile += " filename=\"" + fileName + "\"" + LINE_END;
                 multipartFile += "Content-Type: " + mimeType + LINE_END + LINE_END;
 


### PR DESCRIPTION
fileKey in case  of base64 data in Windows upload form is hard-coded
to "file". It must be set according to options.fileKey provided by user.
