### PR TITLE
CB-10782: Occasional failure in file transfer tests causing mobilespec crash

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -21,7 +21,7 @@
 
 /* global exports, cordova, FileTransfer, FileTransferError, FileUploadOptions, LocalFileSystem */
 
-/* global describe, it, expect, beforeEach, afterEach, spyOn, jasmine, pending */
+/* jshint jasmine: true */
 
 exports.defineAutoTests = function () {
 
@@ -97,8 +97,8 @@ exports.defineAutoTests = function () {
     });
 
     describe("FileTransfer", function () {
-
-        var persistentRoot, tempRoot;
+        this.persistentRoot = null;
+        this.tempRoot       = null;
 
         // named callbacks
         var unexpectedCallbacks = {
@@ -135,7 +135,12 @@ exports.defineAutoTests = function () {
             );
         };
 
-        var writeFile = function (fileSystem, name, content, success) {
+        var writeFile = function (fileSystem, name, content, success, done) {
+            var fileOperationFail = function() {
+                unexpectedCallbacks.fileOperationFail();
+                done();
+            };
+
             fileSystem.getFile(name, { create: true },
                 function (fileEntry) {
                     fileEntry.createWriter(function (writer) {
@@ -159,7 +164,7 @@ exports.defineAutoTests = function () {
                             writer.write(content + "\n");
                         }
 
-                    }, unexpectedCallbacks.fileOperationFail);
+                    }, fileOperationFail);
                 },
                 function () {
                     throw new Error("could not create test file '" + name + "'");
@@ -203,9 +208,11 @@ exports.defineAutoTests = function () {
         //      signifies a completed async call, each async call needs its own done(), and
         //      therefore its own beforeEach
         beforeEach(function (done) {
+            var specContext = this;
+
             window.requestFileSystem(LocalFileSystem.PERSISTENT, DEFAULT_FILESYSTEM_SIZE,
                 function (fileSystem) {
-                    persistentRoot = fileSystem.root;
+                    specContext.persistentRoot = fileSystem.root;
                     done();
                 },
                 function () {
@@ -215,9 +222,11 @@ exports.defineAutoTests = function () {
         });
 
         beforeEach(function (done) {
+            var specContext = this;
+
             window.requestFileSystem(LocalFileSystem.TEMPORARY, DEFAULT_FILESYSTEM_SIZE,
                 function (fileSystem) {
-                    tempRoot = fileSystem.root;
+                    specContext.tempRoot = fileSystem.root;
                     done();
                 },
                 function () {
@@ -259,8 +268,8 @@ exports.defineAutoTests = function () {
         });
 
         it("should initialise correctly", function() {
-            expect(persistentRoot).toBeDefined();
-            expect(tempRoot).toBeDefined();
+            expect(this.persistentRoot).toBeDefined();
+            expect(this.tempRoot).toBeDefined();
         });
 
         it("should exist", function () {
@@ -284,26 +293,24 @@ exports.defineAutoTests = function () {
         });
 
         describe("methods", function() {
-
-            var transfer;
-
-            var root;
-            var fileName;
-            var localFilePath;
+            this.transfer       = null;
+            this.root           = null;
+            this.fileName       = null;
+            this.localFilePath  = null;
 
             beforeEach(function() {
 
-                transfer = new FileTransfer();
+                this.transfer = new FileTransfer();
 
                 // assign onprogress handler
-                transfer.onprogress = isWP8 ? wp8OnProgressHandler : defaultOnProgressHandler;
+                this.transfer.onprogress = isWP8 ? wp8OnProgressHandler : defaultOnProgressHandler;
 
                 // spy on the onprogress handler, but still call through to it
-                spyOn(transfer, "onprogress").and.callThrough();
+                spyOn(this.transfer, "onprogress").and.callThrough();
 
-                root          = persistentRoot;
-                fileName      = "testFile.txt";
-                localFilePath = root.toURL() + fileName;
+                this.root          = this.persistentRoot;
+                this.fileName      = "testFile.txt";
+                this.localFilePath = this.root.toURL() + this.fileName;
             });
 
             // NOTE:
@@ -315,27 +322,28 @@ exports.defineAutoTests = function () {
             describe("download", function () {
 
                 // helpers
-                var verifyDownload = function (fileEntry) {
-                    expect(fileEntry.name).toBe(fileName);
+                var verifyDownload = function (fileEntry, specContext) {
+                    expect(fileEntry.name).toBe(specContext.fileName);
                 };
 
                 // delete the downloaded file
                 afterEach(function (done) {
-                    deleteFile(root, fileName, done);
+                    deleteFile(this.root, this.fileName, done);
                 });
 
                 it("ensures that test file does not exist", function (done) {
-                    deleteFile(root, fileName, done);
+                    deleteFile(this.root, this.fileName, done);
                 });
 
                 it("filetransfer.spec.4 should download a file", function (done) {
 
                     var fileURL = SERVER + "/robots.txt";
+                    var specContext = this;
 
                     var fileWin = function (blob) {
 
-                        if (transfer.onprogress.calls.any()) {
-                            var lastProgressEvent = transfer.onprogress.calls.mostRecent().args[0];
+                        if (specContext.transfer.onprogress.calls.any()) {
+                            var lastProgressEvent = specContext.transfer.onprogress.calls.mostRecent().args[0];
                             expect(lastProgressEvent.loaded).not.toBeGreaterThan(blob.size);
                         } else {
                             console.log("no progress events were emitted");
@@ -344,27 +352,43 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    var downloadWin = function (entry) {
-
-                        verifyDownload(entry);
-
-                        // verify the FileEntry representing this file
-                        entry.file(fileWin, unexpectedCallbacks.fileSystemFail);
+                    var fileSystemFail = function() {
+                        unexpectedCallbacks.fileSystemFail();
+                        done();
                     };
 
-                    transfer.download(fileURL, localFilePath, downloadWin, unexpectedCallbacks.httpFail);
+                    var downloadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
+                    var downloadWin = function (entry) {
+
+                        verifyDownload(entry, specContext);
+
+                        // verify the FileEntry representing this file
+                        entry.file(fileWin, fileSystemFail);
+                    };
+
+                    specContext.transfer.download(fileURL, specContext.localFilePath, downloadWin, downloadFail);
                 }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.5 should download a file using http basic auth", function (done) {
 
                     var fileURL = SERVER_WITH_CREDENTIALS + "/download_basic_auth";
+                    var specContext = this;
 
                     var downloadWin = function (entry) {
-                        verifyDownload(entry);
+                        verifyDownload(entry, specContext);
                         done();
                     };
 
-                    transfer.download(fileURL, localFilePath, downloadWin, unexpectedCallbacks.httpFail);
+                    var downloadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
+                    specContext.transfer.download(fileURL, specContext.localFilePath, downloadWin, downloadFail);
                 }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.6 should get 401 status on http basic auth failure", function (done) {
@@ -379,7 +403,12 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    transfer.download(fileURL, localFilePath, unexpectedCallbacks.httpWin, downloadFail, null,
+                    var downloadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    this.transfer.download(fileURL, this.localFilePath, downloadWin, downloadFail, null,
                         {
                             headers: {
                                 "If-Modified-Since": "Thu, 19 Mar 2015 00:00:00 GMT"
@@ -396,6 +425,7 @@ exports.defineAutoTests = function () {
                     }
 
                     var fileURL = window.location.protocol + "//" + window.location.pathname.replace(/ /g, "%20");
+                    var specContext = this;
 
                     if (!/^file:/.exec(fileURL) && cordova.platformId !== "blackberry10") {
                         if (cordova.platformId === "windowsphone") {
@@ -406,22 +436,43 @@ exports.defineAutoTests = function () {
                     }
 
                     var downloadWin = function (entry) {
-                        verifyDownload(entry);
+                        verifyDownload(entry, specContext);
                         done();
                     };
 
-                    transfer.download(fileURL, localFilePath, downloadWin, unexpectedCallbacks.httpFail);
+                    var downloadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
+                    specContext.transfer.download(fileURL, specContext.localFilePath, downloadWin, downloadFail);
                 }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.8 should download a file using https://", function (done) {
 
                     var fileURL = "https://www.apache.org/licenses/";
+                    var specContext = this;
+
+                    var downloadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
+                    var fileOperationFail = function() {
+                        unexpectedCallbacks.fileOperationFail();
+                        done();
+                    };
+
+                    var fileSystemFail = function() {
+                        unexpectedCallbacks.fileSystemFail();
+                        done();
+                    };
 
                     var fileWin = function (file) {
 
                         var reader = new FileReader();
 
-                        reader.onerror = unexpectedCallbacks.fileOperationFail;
+                        reader.onerror = fileOperationFail;
                         reader.onload  = function () {
                             expect(reader.result).toMatch(/The Apache Software Foundation/);
                             done();
@@ -431,57 +482,83 @@ exports.defineAutoTests = function () {
                     };
 
                     var downloadWin = function (entry) {
-                        verifyDownload(entry);
-                        entry.file(fileWin, unexpectedCallbacks.fileSystemFail);
+                        verifyDownload(entry, specContext);
+                        entry.file(fileWin, fileSystemFail);
                     };
 
-                    transfer.download(fileURL, localFilePath, downloadWin, unexpectedCallbacks.httpFail);
+                    specContext.transfer.download(fileURL, specContext.localFilePath, downloadWin, downloadFail);
                 }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.11 should call the error callback on abort()", function (done) {
 
                     var fileURL = "http://cordova.apache.org/downloads/BlueZedEx.mp3";
                     fileURL = fileURL + "?q=" + (new Date()).getTime();
+                    var specContext = this;
 
-                    transfer.download(fileURL, localFilePath, unexpectedCallbacks.httpWin, done);
+                    var downloadWin = function () {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    specContext.transfer.download(fileURL, specContext.localFilePath, downloadWin, done);
                     setTimeout(function() {
-                        transfer.abort();
+                        specContext.transfer.abort();
                     }, ABORT_DELAY);
                 }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.9 should not leave partial file due to abort", function (done) {
 
                     var fileURL = "http://cordova.apache.org/downloads/logos_2.zip";
+                    var specContext = this;
+
+                    var fileSystemWin = function() {
+                        unexpectedCallbacks.fileSystemWin();
+                        done();
+                    };
+
+                    var downloadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
 
                     var downloadFail = function (error) {
 
-                        expect(error.code).toBe(FileTransferError.ABORT_ERR);
-                        expect(transfer.onprogress).toHaveBeenCalled();
+                        var result = (error.code === FileTransferError.ABORT_ERR || error.code === FileTransferError.CONNECTION_ERR)? true: false;
+                        if (!result) {
+                            fail("Expected " + error.code + " to be " + FileTransferError.ABORT_ERR + " or " + FileTransferError.CONNECTION_ERR);
+                        }
+                        expect(specContext.transfer.onprogress).toHaveBeenCalled();
 
                         // check that there is no file
-                        root.getFile(fileName, null, unexpectedCallbacks.fileSystemWin, done);
+                        specContext.root.getFile(specContext.fileName, null, fileSystemWin, done);
                     };
 
                     // abort at the first onprogress event
-                    transfer.onprogress = function (event) {
+                    specContext.transfer.onprogress = function (event) {
                         if (event.loaded > 0) {
-                            transfer.abort();
+                            specContext.transfer.abort();
                         }
                     };
 
-                    spyOn(transfer, "onprogress").and.callThrough();
+                    spyOn(specContext.transfer, "onprogress").and.callThrough();
 
-                    transfer.download(fileURL, localFilePath, unexpectedCallbacks.httpWin, downloadFail);
+                    specContext.transfer.download(fileURL, specContext.localFilePath, downloadWin, downloadFail);
                 }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.10 should be stopped by abort() right away", function (done) {
 
                     var fileURL = "http://cordova.apache.org/downloads/BlueZedEx.mp3";
                     fileURL = fileURL + "?q=" + (new Date()).getTime();
+                    var specContext = this;
 
-                    expect(transfer.abort).not.toThrow(); // should be a no-op.
+                    expect(specContext.transfer.abort).not.toThrow(); // should be a no-op.
 
                     var startTime = +new Date();
+
+                    var downloadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
 
                     var downloadFail = function (error) {
 
@@ -492,14 +569,14 @@ exports.defineAutoTests = function () {
                         setTimeout(done, GRACE_TIME_DELTA * 2);
                     };
 
-                    transfer.download(fileURL, localFilePath, unexpectedCallbacks.httpWin, downloadFail);
+                    specContext.transfer.download(fileURL, specContext.localFilePath, downloadWin, downloadFail);
                     setTimeout(function() {
-                        transfer.abort();
+                        specContext.transfer.abort();
                     }, ABORT_DELAY);
 
                     // call abort() again, after a time greater than the grace period
                     setTimeout(function () {
-                        expect(transfer.abort).not.toThrow();
+                        expect(specContext.transfer.abort).not.toThrow();
                     }, GRACE_TIME_DELTA);
                 }, DOWNLOAD_TIMEOUT);
 
@@ -522,7 +599,12 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    transfer.download(fileURL, localFilePath, unexpectedCallbacks.httpWin, downloadFail);
+                    var downloadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    this.transfer.download(fileURL, this.localFilePath, downloadWin, downloadFail);
                 }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.13 should get http body on failure", function (done) {
@@ -540,7 +622,12 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    transfer.download(fileURL, localFilePath, unexpectedCallbacks.httpWin, downloadFail);
+                    var downloadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    this.transfer.download(fileURL, this.localFilePath, downloadWin, downloadFail);
                 }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.14 should handle malformed urls", function (done) {
@@ -558,7 +645,12 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    transfer.download(fileURL, localFilePath, unexpectedCallbacks.httpWin, downloadFail);
+                    var downloadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    this.transfer.download(fileURL, this.localFilePath, downloadWin, downloadFail);
                 });
 
                 it("filetransfer.spec.15 should handle unknown host", function (done) {
@@ -569,15 +661,26 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    // turn off the onprogress handler
-                    transfer.onprogress = function () {};
+                    var downloadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
 
-                    transfer.download(fileURL, localFilePath, unexpectedCallbacks.httpWin, downloadFail);
+                    // turn off the onprogress handler
+                    this.transfer.onprogress = function () {};
+
+                    this.transfer.download(fileURL, this.localFilePath, downloadWin, downloadFail);
                 }, isWindows ? WINDOWS_UNKNOWN_HOST_TIMEOUT : DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.16 should handle bad file path", function (done) {
                     var fileURL = SERVER;
-                    transfer.download(fileURL, "c:\\54321", unexpectedCallbacks.httpWin, done);
+
+                    var downloadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    this.transfer.download(fileURL, "c:\\54321", downloadWin, done);
                 });
 
                 it("filetransfer.spec.17 progress should work with gzip encoding", function (done) {
@@ -589,13 +692,19 @@ exports.defineAutoTests = function () {
                     }
 
                     var fileURL = "http://www.apache.org/";
+                    var specContext = this;
 
                     var downloadWin = function (entry) {
-                        verifyDownload(entry);
+                        verifyDownload(entry, specContext);
                         done();
                     };
 
-                    transfer.download(fileURL, localFilePath, downloadWin, unexpectedCallbacks.httpFail);
+                    var downloadFail = function () {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
+                    specContext.transfer.download(fileURL, specContext.localFilePath, downloadWin,downloadFail);
                 }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.30 downloaded file entries should have a toNativeURL method", function (done) {
@@ -628,12 +737,18 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    transfer.download(fileURL, localFilePath, downloadWin, unexpectedCallbacks.httpFail);
+                    var downloadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
+                    this.transfer.download(fileURL, this.localFilePath, downloadWin, downloadFail);
                 }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.28 (compatibility) should be able to download a file using local paths", function (done) {
 
                     var fileURL = SERVER + "/robots.txt";
+                    var specContext = this;
 
                     var unsupported = function (response) {
                         expectedCallbacks.unsupportedOperation(response);
@@ -641,15 +756,20 @@ exports.defineAutoTests = function () {
                     };
 
                     var downloadWin = function (entry) {
-                        verifyDownload(entry);
+                        verifyDownload(entry, specContext);
                         done();
                     };
 
                     var internalFilePath;
-                    if (root.toInternalURL) {
-                        internalFilePath = root.toInternalURL() + fileName;
+                    if (specContext.root.toInternalURL) {
+                        internalFilePath = specContext.root.toInternalURL() + specContext.fileName;
                     } else {
-                        internalFilePath = localFilePath;
+                        internalFilePath = specContext.localFilePath;
+                    }
+
+                    var downloadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
                     }
 
                     // This is an undocumented interface to File which exists only for testing
@@ -657,7 +777,7 @@ exports.defineAutoTests = function () {
                     // location, we can pass that to transfer.download() to make sure that previously-stored
                     // paths are still valid.
                     cordova.exec(function (localPath) {
-                        transfer.download(fileURL, localPath, downloadWin, unexpectedCallbacks.httpFail);
+                        specContext.transfer.download(fileURL, localPath, downloadWin, downloadFail);
                     }, unsupported, "File", "_getLocalFilesystemPath", [internalFilePath]);
                 });
 
@@ -677,7 +797,12 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    transfer.download(imageURL + "?q=" + lastModified.getTime(), localFilePath, unexpectedCallbacks.httpWin, downloadFail, null,
+                    var downloadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    this.transfer.download(imageURL + "?q=" + lastModified.getTime(), this.localFilePath, downloadWin, downloadFail, null,
                         {
                             headers: {
                                 "If-Modified-Since": lastModified.toUTCString()
@@ -694,17 +819,38 @@ exports.defineAutoTests = function () {
 
                     var imageURL = "http://apache.org/images/feather-small.gif";
                     var lastModified = new Date();
+                    var specContext = this;
+
+                    var fileOperationFail = function() {
+                        unexpectedCallbacks.fileOperationFail();
+                        done();
+                    };
+
+                    var fileSystemFail = function() {
+                        unexpectedCallbacks.fileSystemFail();
+                        done();
+                    };
+
+                    var httpWin =  function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    var httpFail =  function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
 
                     var downloadFail = function (error) {
                         expect(error.http_status).toBe(304);
                         expect(error.code).toBe(FileTransferError.NOT_MODIFIED_ERR);
 
-                        persistentRoot.getFile(fileName, { create: false },
+                        specContext.persistentRoot.getFile(specContext.fileName, { create: false },
                             function (entry) {
                                 var fileWin = function (file) {
                                     var reader = new FileReader();
 
-                                    reader.onerror = unexpectedCallbacks.fileOperationFail;
+                                    reader.onerror = fileOperationFail;
                                     reader.onloadend  = function () {
 
                                         expect(reader.result).toBeTruthy();
@@ -718,10 +864,10 @@ exports.defineAutoTests = function () {
                                     reader.readAsBinaryString(file);
                                 };
 
-                                entry.file(fileWin, unexpectedCallbacks.fileSystemFail);
+                                entry.file(fileWin, fileSystemFail);
                             },
                             function (err) {
-                                expect("Could not open test file '" + fileName + "': " + JSON.stringify(err)).not.toBeDefined();
+                                expect("Could not open test file '" + specContext.fileName + "': " + JSON.stringify(err)).not.toBeDefined();
                                 done();
                             }
                         );
@@ -729,14 +875,14 @@ exports.defineAutoTests = function () {
 
                     // Adding parameters to the requests to avoid caching on iOS, which leads to 200
                     // instead of 304 in result of the second request. (a similar issue is described in CB-8606, CB-10088)
-                    transfer.download(imageURL + "?q=" + lastModified.getTime(), localFilePath, function () {
-                        transfer.download(imageURL + "?q=" + (lastModified.getTime() + 1), localFilePath, unexpectedCallbacks.httpWin, downloadFail, null,
+                    specContext.transfer.download(imageURL + "?q=" + lastModified.getTime(), specContext.localFilePath, function () {
+                        specContext.transfer.download(imageURL + "?q=" + (lastModified.getTime() + 1), specContext.localFilePath, httpWin, downloadFail, null,
                         {
                             headers: {
                                 "If-Modified-Since": lastModified.toUTCString()
                             }
                         });
-                    }, unexpectedCallbacks.httpFail);
+                    }, httpFail);
                 }, DOWNLOAD_TIMEOUT * 2);
 
                 it("filetransfer.spec.36 should handle non-UTF8 encoded download response", function (done) {
@@ -747,11 +893,27 @@ exports.defineAutoTests = function () {
                     }
 
                     var fileURL = SERVER + '/download_non_utf';
+                    var specContext = this;
+
+                    var fileOperationFail = function() {
+                        unexpectedCallbacks.fileOperationFail();
+                        done();
+                    };
+
+                    var fileSystemFail = function() {
+                        unexpectedCallbacks.fileSystemFail();
+                        done();
+                    };
+
+                    var httpFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
 
                     var fileWin = function (blob) {
 
-                        if (transfer.onprogress.calls.any()) {
-                            var lastProgressEvent = transfer.onprogress.calls.mostRecent().args[0];
+                        if (specContext.transfer.onprogress.calls.any()) {
+                            var lastProgressEvent = specContext.transfer.onprogress.calls.mostRecent().args[0];
                             expect(lastProgressEvent.loaded).not.toBeGreaterThan(blob.size);
                         } else {
                             console.log("no progress events were emitted");
@@ -761,7 +923,7 @@ exports.defineAutoTests = function () {
 
                         var reader = new FileReader();
 
-                        reader.onerror = unexpectedCallbacks.fileOperationFail;
+                        reader.onerror = fileOperationFail;
                         reader.onloadend  = function () {
                             expect(reader.result.indexOf(LATIN1_SYMBOLS)).not.toBe(-1);
                             done();
@@ -772,27 +934,25 @@ exports.defineAutoTests = function () {
 
                     var downloadWin = function (entry) {
 
-                        verifyDownload(entry);
+                        verifyDownload(entry, specContext);
 
                         // verify the FileEntry representing this file
-                        entry.file(fileWin, unexpectedCallbacks.fileSystemFail);
+                        entry.file(fileWin, fileSystemFail);
                     };
 
-                    transfer.download(fileURL, localFilePath, downloadWin, unexpectedCallbacks.httpFail);
+                    specContext.transfer.download(fileURL, specContext.localFilePath, downloadWin, httpFail);
                 }, UPLOAD_TIMEOUT);
             });
 
             describe("upload", function() {
-
-                var uploadParams;
-                var uploadOptions;
-
-                var fileName;
-                var fileContents;
-                var localFilePath;
+                this.uploadParams   = null;
+                this.uploadOptions  = null;
+                this.fileName       = null;
+                this.fileContents   = null;
+                this.localFilePath  = null;
 
                 // helpers
-                var verifyUpload = function (uploadResult) {
+                var verifyUpload = function (uploadResult, specContext) {
 
                     expect(uploadResult.bytesSent).toBeGreaterThan(0);
                     expect(uploadResult.responseCode).toBe(200);
@@ -807,45 +967,47 @@ exports.defineAutoTests = function () {
                         expect(obj).not.toBeNull("returned data from server should be valid json");
                     }
 
-                    expect(transfer.onprogress).toHaveBeenCalled();
+                    expect(specContext.transfer.onprogress).toHaveBeenCalled();
                 };
 
                 beforeEach(function(done) {
+                    var specContext = this;
 
-                    fileName      = "fileToUpload.txt";
-                    fileContents  = "upload test file";
+                    specContext.fileName               = "fileToUpload.txt";
+                    specContext.fileContents           = "upload test file";
 
-                    uploadParams        = {};
-                    uploadParams.value1 = "test";
-                    uploadParams.value2 = "param";
+                    specContext.uploadParams           = {};
+                    specContext.uploadParams.value1    = "test";
+                    specContext.uploadParams.value2    = "param";
 
-                    uploadOptions          = new FileUploadOptions();
-                    uploadOptions.fileKey  = "file";
-                    uploadOptions.fileName = fileName;
-                    uploadOptions.mimeType = "text/plain";
-                    uploadOptions.params   = uploadParams;
+                    specContext.uploadOptions          = new FileUploadOptions();
+                    specContext.uploadOptions.fileKey  = "file";
+                    specContext.uploadOptions.fileName = specContext.fileName;
+                    specContext.uploadOptions.mimeType = "text/plain";
+                    specContext.uploadOptions.params   = specContext.uploadParams;
 
                     var fileWin = function (entry) {
-                        localFilePath = entry.toURL();
+                        specContext.localFilePath = entry.toURL();
                         done();
                     };
 
                     // create a file to upload
-                    writeFile(root, fileName, fileContents, fileWin);
+                    writeFile(specContext.root, specContext.fileName, specContext.fileContents, fileWin, done);
                 });
 
                 // delete the uploaded file
                 afterEach(function (done) {
-                    deleteFile(root, fileName, done);
+                    deleteFile(this.root, this.fileName, done);
                 });
 
                 it("filetransfer.spec.18 should be able to upload a file", function (done) {
 
                     var fileURL = SERVER + "/upload";
+                    var specContext = this;
 
                     var uploadWin = function (uploadResult) {
 
-                        verifyUpload(uploadResult);
+                        verifyUpload(uploadResult, specContext);
 
                         if (cordova.platformId === "ios") {
                             expect(uploadResult.headers).toBeDefined("Expected headers to be defined.");
@@ -855,27 +1017,39 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
+                    var uploadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
                     // NOTE: removing uploadOptions cause Android to timeout
-                    transfer.upload(localFilePath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptions);
+                    specContext.transfer.upload(specContext.localFilePath, fileURL, uploadWin, uploadFail, specContext.uploadOptions);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.19 should be able to upload a file with http basic auth", function (done) {
 
                     var fileURL = SERVER_WITH_CREDENTIALS + "/upload_basic_auth";
+                    var specContext = this;
 
                     var uploadWin = function (uploadResult) {
-                        verifyUpload(uploadResult);
+                        verifyUpload(uploadResult, specContext);
+                        done();
+                    };
+
+                    var uploadFail = function() {
+                        unexpectedCallbacks.httpFail();
                         done();
                     };
 
                     // NOTE: removing uploadOptions cause Android to timeout
-                    transfer.upload(localFilePath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptions);
+                    specContext.transfer.upload(specContext.localFilePath, fileURL, uploadWin, uploadFail, specContext.uploadOptions);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.21 should be stopped by abort() right away", function (done) {
 
                     var fileURL = SERVER + "/upload";
                     var startTime;
+                    var specContext = this;
 
                     var uploadFail = function (e) {
                         expect(e.code).toBe(FileTransferError.ABORT_ERR);
@@ -885,24 +1059,29 @@ exports.defineAutoTests = function () {
                         setTimeout(done, GRACE_TIME_DELTA * 2);
                     };
 
+                    var uploadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
                     var fileWin = function () {
 
                         startTime = +new Date();
 
-                        expect(transfer.abort).not.toThrow();
+                        expect(specContext.transfer.abort).not.toThrow();
 
                         // NOTE: removing uploadOptions cause Android to timeout
-                        transfer.upload(localFilePath, fileURL, unexpectedCallbacks.httpWin, uploadFail, uploadOptions);
+                        specContext.transfer.upload(specContext.localFilePath, fileURL, uploadWin, uploadFail, specContext.uploadOptions);
                         setTimeout(function() {
-                            transfer.abort();
+                            specContext.transfer.abort();
                         }, ABORT_DELAY);
 
                         setTimeout(function () {
-                            expect(transfer.abort).not.toThrow();
+                            expect(specContext.transfer.abort).not.toThrow();
                         }, GRACE_TIME_DELTA);
                     };
 
-                    writeFile(root, fileName, new Array(200000).join("aborttest!"), fileWin);
+                    writeFile(specContext.root, specContext.fileName, new Array(200000).join("aborttest!"), fileWin, done);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.22 should get http status and body on failure", function (done) {
@@ -915,7 +1094,12 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    transfer.upload(localFilePath, fileURL, unexpectedCallbacks.httpWin, uploadFail, uploadOptions);
+                    var uploadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    this.transfer.upload(this.localFilePath, fileURL, uploadWin, uploadFail, this.uploadOptions);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.24 should handle malformed urls", function (done) {
@@ -928,7 +1112,12 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    transfer.upload(localFilePath, fileURL, unexpectedCallbacks.httpWin, uploadFail, {});
+                    var uploadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    this.transfer.upload(this.localFilePath, fileURL, uploadWin, uploadFail, {});
                 });
 
                 it("filetransfer.spec.25 should handle unknown host", function (done) {
@@ -941,7 +1130,12 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    transfer.upload(localFilePath, fileURL, unexpectedCallbacks.httpWin, uploadFail, {});
+                    var uploadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    this.transfer.upload(this.localFilePath, fileURL, uploadWin, uploadFail, {});
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.25 should handle missing file", function (done) {
@@ -954,7 +1148,12 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    transfer.upload("does_not_exist.txt", fileURL, unexpectedCallbacks.httpWin, uploadFail);
+                    var uploadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    this.transfer.upload("does_not_exist.txt", fileURL, uploadWin, uploadFail);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.26 should handle bad file path", function (done) {
@@ -966,7 +1165,12 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    transfer.upload("c:\\54321", fileURL, unexpectedCallbacks.httpWin, uploadFail);
+                    var uploadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
+                    this.transfer.upload("c:\\54321", fileURL, uploadWin, uploadFail);
                 });
 
                 it("filetransfer.spec.27 should be able to set custom headers", function (done) {
@@ -987,18 +1191,24 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    uploadOptions.headers = {
+                    var uploadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
+                    this.uploadOptions.headers = {
                         "CustomHeader1": "CustomValue1",
                         "CustomHeader2": ["CustomValue2", "CustomValue3"],
                     };
 
                     // NOTE: removing uploadOptions cause Android to timeout
-                    transfer.upload(localFilePath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptions);
+                    this.transfer.upload(this.localFilePath, fileURL, uploadWin, uploadFail, this.uploadOptions);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.29 (compatibility) should be able to upload a file using local paths", function (done) {
 
                     var fileURL = SERVER + "/upload";
+                    var specContext = this;
 
                     var unsupported = function (response) {
                         expectedCallbacks.unsupportedOperation(response);
@@ -1006,15 +1216,20 @@ exports.defineAutoTests = function () {
                     };
 
                     var uploadWin = function (uploadResult) {
-                        verifyUpload(uploadResult);
+                        verifyUpload(uploadResult, specContext);
                         done();
                     };
 
+                    var uploadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    }
+
                     var internalFilePath;
-                    if (root.toInternalURL) {
-                        internalFilePath = root.toInternalURL() + fileName;
+                    if (specContext.root.toInternalURL) {
+                        internalFilePath = specContext.root.toInternalURL() + specContext.fileName;
                     } else {
-                        internalFilePath = localFilePath;
+                        internalFilePath = specContext.localFilePath;
                     }
 
                     // This is an undocumented interface to File which exists only for testing
@@ -1022,17 +1237,18 @@ exports.defineAutoTests = function () {
                     // location, we can pass that to transfer.download() to make sure that previously-stored
                     // paths are still valid.
                     cordova.exec(function (localPath) {
-                        transfer.upload(localPath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptions);
+                        specContext.transfer.upload(localPath, fileURL, uploadWin, uploadFail, specContext.uploadOptions);
                     }, unsupported, "File", "_getLocalFilesystemPath", [internalFilePath]);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.31 should be able to upload a file using PUT method", function (done) {
 
                     var fileURL = SERVER + "/upload";
+                    var specContext = this;
 
                     var uploadWin = function (uploadResult) {
 
-                        verifyUpload(uploadResult);
+                        verifyUpload(uploadResult, specContext);
 
                         if (cordova.platformId === "ios") {
                             expect(uploadResult.headers).toBeDefined("Expected headers to be defined.");
@@ -1042,15 +1258,21 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    uploadOptions.httpMethod = "PUT";
+                    var uploadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
+                    specContext.uploadOptions.httpMethod = "PUT";
 
                     // NOTE: removing uploadOptions cause Android to timeout
-                    transfer.upload(localFilePath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptions);
+                    specContext.transfer.upload(specContext.localFilePath, fileURL, uploadWin, uploadFail, specContext.uploadOptions);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.32 should be able to upload a file (non-multipart)", function (done) {
 
                     var fileURL = SERVER + "/upload";
+                    var specContext = this;
 
                     var uploadWin = function (uploadResult) {
 
@@ -1058,9 +1280,9 @@ exports.defineAutoTests = function () {
                         expect(uploadResult.responseCode).toBe(200);
                         expect(uploadResult.response).toBeDefined();
                         if (uploadResult.response) {
-                            expect(uploadResult.response).toEqual(fileContents + "\n");
+                            expect(uploadResult.response).toEqual(specContext.fileContents + "\n");
                         }
-                        expect(transfer.onprogress).toHaveBeenCalled();
+                        expect(specContext.transfer.onprogress).toHaveBeenCalled();
 
                         if (cordova.platformId === "ios") {
                             expect(uploadResult.headers).toBeDefined("Expected headers to be defined.");
@@ -1070,25 +1292,31 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
+                    var uploadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
                     // Content-Type header disables multipart
-                    uploadOptions.headers = {
+                    specContext.uploadOptions.headers = {
                         "Content-Type": "text/plain"
                     };
 
                     // NOTE: removing uploadOptions cause Android to timeout
-                    transfer.upload(localFilePath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptions);
+                    specContext.transfer.upload(specContext.localFilePath, fileURL, uploadWin, uploadFail, specContext.uploadOptions);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.34 should not delete a file on upload error", function (done) {
 
                     var fileURL = SERVER + "/upload";
+                    var specContext = this;
 
                     var uploadFail = function (e) {
                         expect(e.code).toBe(FileTransferError.ABORT_ERR);
-                        expect(transfer.onprogress).toHaveBeenCalled();
+                        expect(specContext.transfer.onprogress).toHaveBeenCalled();
 
                         // check that the file is there
-                        root.getFile(fileName, null, function(entry) {
+                        specContext.root.getFile(specContext.fileName, null, function(entry) {
                             expect(entry).toBeDefined();
 
                             // delay calling done() to wait for the bogus abort()
@@ -1099,24 +1327,29 @@ exports.defineAutoTests = function () {
                         });
                     };
 
+                    var uploadWin = function() {
+                        unexpectedCallbacks.httpWin();
+                        done();
+                    };
+
                     var fileWin = function () {
 
-                        expect(transfer.abort).not.toThrow();
-
-                        // NOTE: removing uploadOptions cause Android to timeout
-                        transfer.upload(localFilePath, fileURL, unexpectedCallbacks.httpWin, uploadFail, uploadOptions);
+                        expect(specContext.transfer.abort).not.toThrow();
 
                         // abort at the first onprogress event
-                        transfer.onprogress = function (event) {
+                        specContext.transfer.onprogress = function (event) {
                             if (event.loaded > 0) {
-                                transfer.abort();
+                                specContext.transfer.abort();
                             }
                         };
 
-                        spyOn(transfer, "onprogress").and.callThrough();
+                        spyOn(specContext.transfer, "onprogress").and.callThrough();
+
+                        // NOTE: removing uploadOptions cause Android to timeout
+                        specContext.transfer.upload(specContext.localFilePath, fileURL, uploadWin, uploadFail, specContext.uploadOptions);
                     };
 
-                    writeFile(root, fileName, new Array(100000).join("aborttest!"), fileWin);
+                    writeFile(specContext.root, specContext.fileName, new Array(100000).join("aborttest!"), fileWin, done);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.37 should handle non-UTF8 encoded upload response", function (done) {
@@ -1127,10 +1360,11 @@ exports.defineAutoTests = function () {
                     }
 
                     var fileURL = SERVER + '/upload_non_utf';
+                    var specContext = this;
 
                     var uploadWin = function (uploadResult) {
 
-                        verifyUpload(uploadResult);
+                        verifyUpload(uploadResult, specContext);
 
                         var obj = null;
                         try {
@@ -1148,17 +1382,23 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
+                    var uploadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
                     // NOTE: removing uploadOptions cause Android to timeout
-                    transfer.upload(localFilePath, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptions);
+                    specContext.transfer.upload(specContext.localFilePath, fileURL, uploadWin, uploadFail, specContext.uploadOptions);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.38 should be able to upload a file using data: source uri", function (done) {
 
                     var fileURL = SERVER + "/upload";
+                    var specContext = this;
 
                     var uploadWin = function (uploadResult) {
 
-                        verifyUpload(uploadResult);
+                        verifyUpload(uploadResult,specContext);
 
                         var obj = null;
                         try {
@@ -1178,11 +1418,11 @@ exports.defineAutoTests = function () {
 
                     var dataUri = DATA_URI_PREFIX + DATA_URI_CONTENT;
                     // NOTE: removing uploadOptions cause Android to timeout
-                    transfer.upload(dataUri, fileURL, uploadWin, function (err) {
+                    specContext.transfer.upload(dataUri, fileURL, uploadWin, function (err) {
                         console.error('err: ' + JSON.stringify(err));
                         expect(err).not.toBeDefined();
                         done();
-                    }, uploadOptions);
+                    }, specContext.uploadOptions);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.39 should be able to upload a file using data: source uri (non-multipart)", function (done) {
@@ -1202,14 +1442,19 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
+                    var uploadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
                     // Content-Type header disables multipart
-                    uploadOptions.headers = {
+                    this.uploadOptions.headers = {
                         "Content-Type": "image/png"
                     };
 
                     var dataUri = DATA_URI_PREFIX + DATA_URI_CONTENT;
                     // NOTE: removing uploadOptions cause Android to timeout
-                    transfer.upload(dataUri, fileURL, uploadWin, unexpectedCallbacks.httpFail, uploadOptions);
+                    this.transfer.upload(dataUri, fileURL, uploadWin, uploadFail, this.uploadOptions);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.40 should not fail to upload a file using data: source uri when the data is empty", function (done) {
@@ -1217,8 +1462,14 @@ exports.defineAutoTests = function () {
                     var fileURL = SERVER + "/upload";
 
                     var dataUri = DATA_URI_PREFIX;
+
+                    var uploadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
                     // NOTE: removing uploadOptions cause Android to timeout
-                    transfer.upload(dataUri, fileURL, done, unexpectedCallbacks.httpFail, uploadOptions);
+                    this.transfer.upload(dataUri, fileURL, done, uploadFail, this.uploadOptions);
                 }, UPLOAD_TIMEOUT);
 
                 it("filetransfer.spec.41 should not fail to upload a file using data: source uri when the data is empty (non-multipart)", function (done) {
@@ -1226,16 +1477,22 @@ exports.defineAutoTests = function () {
                     var fileURL = SERVER + "/upload";
 
                     // Content-Type header disables multipart
-                    uploadOptions.headers = {
+                    this.uploadOptions.headers = {
                         "Content-Type": "image/png"
                     };
 
                     // turn off the onprogress handler
-                    transfer.onprogress = function () { };
+                    this.transfer.onprogress = function () { };
 
                     var dataUri = DATA_URI_PREFIX;
+
+                    var uploadFail = function() {
+                        unexpectedCallbacks.httpFail();
+                        done();
+                    };
+
                     // NOTE: removing uploadOptions cause Android to timeout
-                    transfer.upload(dataUri, fileURL, done, unexpectedCallbacks.httpFail, uploadOptions);
+                    this.transfer.upload(dataUri, fileURL, done, uploadFail, this.uploadOptions);
                 }, UPLOAD_TIMEOUT);
             });
         });


### PR DESCRIPTION
This is one of the flaky tests that occurs about 20% of the times in windows store 8.1 platform. But, this has not been reproduced locally. This causes the app to crash. The error message is " Error: Expected a spy, but got Function." Based on the error message, I suspect that the error is related to the issue that the spying is not set correctly on the transfer progress. So, I have modified this code and submitting this for PR.