### PR TITLE
CB-10771: Fixing failure when empty string passed as a value for opti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ A `FileUploadResult` object is passed to the success callback of the
 
 - __withCredentials__: _boolean_ that tells the browser to set the withCredentials flag on the XMLHttpRequest
 
+### Windows Quirks
+
+- An option parameter with empty/null value is excluded in the upload operation due to the Windows API design.
+
 ## download
 
 __Parameters__:

--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -356,7 +356,8 @@ exec(win, fail, 'FileTransfer', 'upload',
                     // adding params supplied to request payload
                     var transferParts = [];
                     for (var key in params) {
-                        if (params.hasOwnProperty(key)) {
+                        // Create content part for params only if value is specified because CreateUploadAsync fails otherwise
+                        if (params.hasOwnProperty(key) && params[key] !== null && params[key] !== undefined && params[key].toString() !== "") {
                             var contentPart = new Windows.Networking.BackgroundTransfer.BackgroundTransferContentPart();
                             contentPart.setHeader("Content-Disposition", "form-data; name=\"" + key + "\"");
                             contentPart.setText(params[key]);


### PR DESCRIPTION
…on parameter in upload function

CreateUploadAsync fails when passed an empty string as a value for SetText function. It also fails when we skip specifying a value for it. So when a user passes an empty string, skip the parameter instead.