### PR TITLE
CB-11316 windows: Added content-type for files

### DIFF
--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -367,6 +367,7 @@ exec(win, fail, 'FileTransfer', 'upload',
 
                     // Adding file to upload to request payload
                     var fileToUploadPart = new Windows.Networking.BackgroundTransfer.BackgroundTransferContentPart(fileKey, fileName);
+                    fileToUploadPart.setHeader("Content-Type", mimeType);
                     fileToUploadPart.setFile(storageFile);
                     transferParts.push(fileToUploadPart);
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Adds Content-Type header for files in the multi-part upload

### What testing has been done on this change?
ran `npm test`

Tested plugin before with this result:
![aapche-before](https://cloud.githubusercontent.com/assets/2751508/16005224/061072c8-315e-11e6-9c7b-3a26c4e7129f.png)

Tested forked change with the following result:
![aapche-after](https://cloud.githubusercontent.com/assets/2751508/16005241/18bfc39c-315e-11e6-9e4b-8fedecdc5443.png)


### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

- added Content-Type header for each file in the multipart upload