### PR TITLE
CB-11497 Use cordova-vm for testing 304 errors

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -784,9 +784,6 @@ exports.defineAutoTests = function () {
                         return;
                     }
 
-                    var imageURL = "http://apache.org/images/feather-small.gif";
-                    var lastModified = new Date();
-
                     var downloadFail = function (error) {
                         expect(error.http_status).toBe(304);
                         expect(error.code).toBe(FileTransferError.NOT_MODIFIED_ERR);
@@ -798,12 +795,7 @@ exports.defineAutoTests = function () {
                         done();
                     };
 
-                    this.transfer.download(imageURL + "?q=" + lastModified.getTime(), this.localFilePath, downloadWin, downloadFail, null,
-                        {
-                            headers: {
-                                "If-Modified-Since": lastModified.toUTCString()
-                            }
-                        });
+                    this.transfer.download(SERVER + '/304', this.localFilePath, downloadWin, downloadFail);
                 }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.35 304 should not result in the deletion of a cached file", function (done) {
@@ -813,8 +805,6 @@ exports.defineAutoTests = function () {
                         return;
                     }
 
-                    var imageURL = "http://apache.org/images/feather-small.gif";
-                    var lastModified = new Date();
                     var specContext = this;
 
                     var fileOperationFail = function() {
@@ -829,11 +819,6 @@ exports.defineAutoTests = function () {
 
                     var httpWin =  function() {
                         unexpectedCallbacks.httpWin();
-                        done();
-                    };
-
-                    var httpFail =  function() {
-                        unexpectedCallbacks.httpFail();
                         done();
                     };
 
@@ -869,17 +854,10 @@ exports.defineAutoTests = function () {
                         );
                     };
 
-                    // Adding parameters to the requests to avoid caching on iOS, which leads to 200
-                    // instead of 304 in result of the second request. (a similar issue is described in CB-8606, CB-10088)
-                    specContext.transfer.download(imageURL + "?q=" + lastModified.getTime(), specContext.localFilePath, function () {
-                        specContext.transfer.download(imageURL + "?q=" + (lastModified.getTime() + 1), specContext.localFilePath, httpWin, downloadFail, null,
-                        {
-                            headers: {
-                                "If-Modified-Since": lastModified.toUTCString()
-                            }
-                        });
-                    }, httpFail);
-                }, DOWNLOAD_TIMEOUT * 2);
+                    writeFile(specContext.root, specContext.fileName, 'Temp data', function () {
+                        specContext.transfer.download(SERVER + '/304', specContext.localFilePath, httpWin, downloadFail);
+                    }, fileOperationFail);
+                }, DOWNLOAD_TIMEOUT);
 
                 it("filetransfer.spec.36 should handle non-UTF8 encoded download response", function (done) {
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All

### What does this PR do?
Replaces external Apache resource to cordova-vm one for HTTP 304 tests. This is needed to resolve intermittent spec 33 and 35 failures on iOS (see https://issues.apache.org/jira/browse/CB-11479 for details)

### What testing has been done on this change?
Ran autotests via paramedic on all main platforms

### Checklist
- [X] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

