### PR TITLE
CB-9027 (android, ios): Expose HTTP client read timeout as option

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -291,6 +291,7 @@ public class FileTransfer extends CordovaPlugin {
         final JSONObject headers = args.optJSONObject(8) == null ? params.optJSONObject("headers") : args.optJSONObject(8);
         final String objectId = args.getString(9);
         final String httpMethod = getArgument(args, 10, "POST");
+        final int timeout = args.optInt(11, 60);
 
         final CordovaResourceApi resourceApi = webView.getResourceApi();
 
@@ -351,6 +352,9 @@ public class FileTransfer extends CordovaPlugin {
                         // Setup the connection not to verify hostnames
                         https.setHostnameVerifier(DO_NOT_VERIFY);
                     }
+
+                    // Client Timeout before returning a 'HTTP 408 Gateway Timeout'
+                    conn.setReadTimeout(timeout * 1000);
 
                     // Allow Inputs
                     conn.setDoInput(true);
@@ -735,6 +739,7 @@ public class FileTransfer extends CordovaPlugin {
         final boolean trustEveryone = args.optBoolean(2);
         final String objectId = args.getString(3);
         final JSONObject headers = args.optJSONObject(4);
+        final int timeout = args.optInt(5, 60);
 
         final Uri sourceUri = resourceApi.remapUri(Uri.parse(source));
         // Accept a path or a URI for the source.
@@ -841,6 +846,9 @@ public class FileTransfer extends CordovaPlugin {
                             https.setHostnameVerifier(DO_NOT_VERIFY);
                         }
 
+                        // Client Timeout before returning a 'HTTP 408 Gateway Timeout'
+                        connection.setReadTimeout(timeout * 1000);
+
                         connection.setRequestMethod("GET");
 
                         // TODO: Make OkHttp use this CookieManager by default.
@@ -900,6 +908,7 @@ public class FileTransfer extends CordovaPlugin {
                                 progressResult.setKeepCallback(true);
                                 context.sendPluginResult(progressResult);
                             }
+                            outputStream.flush();
                         } finally {
                             synchronized (context) {
                                 context.connection = null;

--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -153,6 +153,7 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     // for allowed methods, currently PUT or POST (forces POST for
     // unrecognised values)
     NSString* httpMethod = [command argumentAtIndex:10 withDefault:@"POST"];
+    NSNumber* timeout = [command argumentAtIndex:11 withDefault:[NSNumber numberWithDouble:60]];
     CDVPluginResult* result = nil;
     CDVFileTransferError errorCode = 0;
 
@@ -174,7 +175,7 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     }
 
     NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:url];
-
+    [req setTimeoutInterval:[timeout doubleValue]];
     [req setHTTPMethod:httpMethod];
 
     //    Magic value to set a cookie
@@ -420,6 +421,7 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     BOOL trustAllHosts = [[command argumentAtIndex:2 withDefault:[NSNumber numberWithBool:NO]] boolValue]; // allow self-signed certs
     NSString* objectId = [command argumentAtIndex:3];
     NSDictionary* headers = [command argumentAtIndex:4 withDefault:nil];
+    NSNumber* timeout = [command argumentAtIndex:5 withDefault:[NSNumber numberWithDouble:60]];
 
     CDVPluginResult* result = nil;
     CDVFileTransferError errorCode = 0;
@@ -456,6 +458,7 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     }
 
     NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:sourceURL];
+    [req setTimeoutInterval:[timeout doubleValue]];
     [self applyRequestHeaders:headers toRequest:req];
 
     CDVFileTransferDelegate* delegate = [[CDVFileTransferDelegate alloc] init];

--- a/www/FileTransfer.js
+++ b/www/FileTransfer.js
@@ -110,6 +110,7 @@ FileTransfer.prototype.upload = function(filePath, server, successCallback, erro
     var chunkedMode = true;
     var headers = null;
     var httpMethod = null;
+    var timeout = null;
     var basicAuthHeader = getBasicAuthHeader(server);
     if (basicAuthHeader) {
         server = server.replace(getUrlCredentials(server) + '@', '');
@@ -125,6 +126,7 @@ FileTransfer.prototype.upload = function(filePath, server, successCallback, erro
         mimeType = options.mimeType;
         headers = options.headers;
         httpMethod = options.httpMethod || "POST";
+        timeout = options.timeout;
         if (httpMethod.toUpperCase() == "PUT"){
             httpMethod = "PUT";
         } else {
@@ -163,7 +165,7 @@ FileTransfer.prototype.upload = function(filePath, server, successCallback, erro
             }
         }
     };
-    exec(win, fail, 'FileTransfer', 'upload', [filePath, server, fileKey, fileName, mimeType, params, trustAllHosts, chunkedMode, headers, this._id, httpMethod]);
+    exec(win, fail, 'FileTransfer', 'upload', [filePath, server, fileKey, fileName, mimeType, params, trustAllHosts, chunkedMode, headers, this._id, httpMethod, timeout]);
 };
 
 /**
@@ -189,8 +191,10 @@ FileTransfer.prototype.download = function(source, target, successCallback, erro
     }
 
     var headers = null;
+    var timeout = null;
     if (options) {
         headers = options.headers || null;
+        timeout = options.timeout;
     }
 
     if (cordova.platformId === "windowsphone" && headers) {
@@ -225,7 +229,7 @@ FileTransfer.prototype.download = function(source, target, successCallback, erro
         errorCallback(error);
     };
 
-    exec(win, fail, 'FileTransfer', 'download', [source, target, trustAllHosts, this._id, headers]);
+    exec(win, fail, 'FileTransfer', 'download', [source, target, trustAllHosts, this._id, headers, timeout]);
 };
 
 /**


### PR DESCRIPTION
### Platforms affected
Android
iOS

### What does this PR do?
Expose HTTP Client Read Timeout as option

### What testing has been done on this change?
Android undefined / 60 / 180
iOS undefined / 60 / 180

### Checklist
- [X] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.

