### PR TITLE
CB-11926 Tests can use local server

### DIFF
--- a/tests/hooks/after_prepare.js
+++ b/tests/hooks/after_prepare.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+/*
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*/
+
+var path = require('path');
+var fs = require('fs');
+
+module.exports = function(context) {
+    function main() {
+        // get the file transfer server address from the specified variables
+        var fileTransferServerAddress = getFileTransferServerAddress(context) || getDefaultFileTransferServerAddress(context);
+        console.log('Tests will use the following file transfer server address: ' + fileTransferServerAddress);
+
+        // pass it to the tests
+        writeFileTransferOptions(fileTransferServerAddress, context);
+    }
+
+    function getDefaultFileTransferServerAddress(context) {
+        var address = null;
+        var configNodes = context.opts.plugin.pluginInfo._et._root._children;
+
+        for (var node in configNodes) {
+            if (configNodes[node].attrib.name == 'FILETRANSFER_SERVER_ADDRESS') {
+                address = configNodes[node].attrib.default;
+            }
+        }
+
+        return address;
+    }
+
+    function getFileTransferServerAddress(context) {
+        var platformJsonFile = path.join(context.opts.projectRoot, 'platforms', context.opts.platforms[0], context.opts.platforms[0] + '.json');
+        var platformJson = JSON.parse(fs.readFileSync(platformJsonFile, 'utf8'));
+
+        return platformJson.installed_plugins['cordova-plugin-file-transfer-tests'].FILETRANSFER_SERVER_ADDRESS;
+    }
+
+    function writeFileTransferOptions(address, context) {
+        for (var p in context.opts.paths) {
+            var ftOpts = {
+                serverAddress: address
+            };
+            var ftOptsString = JSON.stringify(ftOpts);
+            var ftOptsFile = path.join(context.opts.paths[p], 'fileTransferOpts.json');
+            fs.writeFileSync(ftOptsFile, ftOptsString, 'utf8');
+        }
+    }
+
+    main();
+
+};

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -27,4 +27,8 @@
 
     <js-module src="tests.js" name="tests">
     </js-module>
+
+    <hook type="after_prepare" src="hooks/after_prepare.js" />
+
+    <preference name="FILETRANSFER_SERVER_ADDRESS" default="http://cordova-vm.apache.org:5000"/>
 </plugin>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -42,11 +42,14 @@ exports.defineAutoTests = function () {
     var DATA_URI_CONTENT = "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==";
     var DATA_URI_CONTENT_LENGTH = 85; // bytes. (This is the raw file size: used https://en.wikipedia.org/wiki/File:Red-dot-5px.png from https://en.wikipedia.org/wiki/Data_URI_scheme)
 
-    // config for upload test server
+    // upload test server address
     // NOTE:
     //      more info at https://github.com/apache/cordova-labs/tree/cordova-filetransfer
-    var SERVER                  = "http://cordova-vm.apache.org:5000";
-    var SERVER_WITH_CREDENTIALS = "http://cordova_user:cordova_password@cordova-vm.apache.org:5000";
+    // Will get it from the config
+    // you can specify it as a 'FILETRANSFER_SERVER_ADDRESS' variable upon test plugin installation
+    // or change the default value in plugin.xml
+    var SERVER = "";
+    var SERVER_WITH_CREDENTIALS = "";
 
     // flags
     var isWindows = cordova.platformId === "windows8" || cordova.platformId === "windows";
@@ -202,6 +205,11 @@ exports.defineAutoTests = function () {
             }
         };
 
+        var setServerAddress = function (address) {
+            SERVER = address;
+            SERVER_WITH_CREDENTIALS = SERVER.replace('http://', 'http://cordova_user:cordova_password@');
+        };
+
         // NOTE:
         //      there are several beforeEach calls, one per async call; since calling done()
         //      signifies a completed async call, each async call needs its own done(), and
@@ -263,6 +271,22 @@ exports.defineAutoTests = function () {
 
             if (expectedCallbacks.unsupportedOperation.calls.any()) {
                 pending();
+            }
+        });
+
+        it ("util spec: get file transfer server url", function () {
+            try {
+                // attempt to synchronously load medic config
+                var xhr = new XMLHttpRequest();
+                xhr.open("GET", "../fileTransferOpts.json", false);
+                xhr.send(null);
+                var parsedCfg = JSON.parse(xhr.responseText);
+                if (parsedCfg.serverAddress) {
+                    setServerAddress(parsedCfg.serverAddress);
+                }
+            } catch (ex) {
+                console.error('Unable to load file transfer server url: ' + ex);
+                fail(ex);
             }
         });
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All

### What does this PR do?
Allows tests to use a locally deployed server. You can specify its address via `--variable FILETRANSFER_SERVER_ADDRESS=http://your.address.here:5000` upon plugin installation.
The server itself can be found at:
https://github.com/apache/cordova-labs/tree/cordova-filetransfer
However, it's easier to just use paramedic, which can deploy this server and patch the tests to use it automatically:
https://github.com/apache/cordova-paramedic/pull/17

### What testing has been done on this change?
Tested w/ and w/o paramedic on Android and Windows platforms.

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

