### PR TITLE
When "Content-Type" has "multipart/form-data", should not contain a "Content-Length" in the boundary area.

### DIFF
--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -220,6 +220,8 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
         [postBodyBeforeFile appendData:[[NSString stringWithFormat:@"Content-Type: %@\r\n", mimeType] dataUsingEncoding:NSUTF8StringEncoding]];
     }
 
+	[postBodyBeforeFile appendData:[[NSString stringWithFormat:@"\r\n"] dataUsingEncoding:NSUTF8StringEncoding]];
+	
     DLog(@"fileData length: %d", [fileData length]);
     NSData* postBodyAfterFile = [[NSString stringWithFormat:@"\r\n--%@--\r\n", kFormBoundary] dataUsingEncoding:NSUTF8StringEncoding];
 

--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -219,7 +219,6 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     if (mimeType != nil) {
         [postBodyBeforeFile appendData:[[NSString stringWithFormat:@"Content-Type: %@\r\n", mimeType] dataUsingEncoding:NSUTF8StringEncoding]];
     }
-    [postBodyBeforeFile appendData:[[NSString stringWithFormat:@"Content-Length: %ld\r\n\r\n", (long)[fileData length]] dataUsingEncoding:NSUTF8StringEncoding]];
 
     DLog(@"fileData length: %d", [fileData length]);
     NSData* postBodyAfterFile = [[NSString stringWithFormat:@"\r\n--%@--\r\n", kFormBoundary] dataUsingEncoding:NSUTF8StringEncoding];

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -19,7 +19,7 @@
 *
 */
 
-/* global exports, cordova, FileTransfer, FileTransferError, FileUploadOptions, LocalFileSystem */
+/* global exports, cordova, FileTransfer, FileTransferError, FileUploadOptions, LocalFileSystem, WinJS */
 
 /* jshint jasmine: true */
 
@@ -53,7 +53,7 @@ exports.defineAutoTests = function () {
 
     // flags
     var isWindows = cordova.platformId === "windows8" || cordova.platformId === "windows";
-    var isWindowsPhone81 = isWindows && WinJS.Utilities.isPhone
+    var isWindowsPhone81 = isWindows && WinJS.Utilities.isPhone;
     var isWP8 = cordova.platformId === "windowsphone";
     var isBrowser = cordova.platformId === "browser";
     var isIE = isBrowser && navigator.userAgent.indexOf("Trident") >= 0;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
### Platforms affected

platform : ios
### What does this PR do?

"https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html" in the article "Multipart Form" of the site, there is no content that ey included the "Content-Length" to the "boundary" region, "boundary "in the region," Content-Type "," Content-Disposition "and it has been seen to have put," Content-Transfer-Encoding "only. Therefore, it is unnecessary source, there is a possibility that the bug occurs, it is assumed that the suit is to delete.
### What testing has been done on this change?

Bug you do not check the "Content-Length" of the boundary in the area occurred in the services currently under development. Once you apply the source, it was Mashi normal operation.
### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

…Content-Length" in the boundary area.
