### PR TITLE
Allowing chunkedMode to be false on Android with uploads over https

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -430,7 +430,7 @@ public class FileTransfer extends CordovaPlugin {
                     // setFixedLengthStreamingMode causes and OutOfMemoryException on pre-Froyo devices.
                     // http://code.google.com/p/android/issues/detail?id=3164
                     // It also causes OOM if HTTPS is used, even on newer devices.
-                    boolean useChunkedMode = chunkedMode || (Build.VERSION.SDK_INT < Build.VERSION_CODES.FROYO || useHttps);
+                    boolean useChunkedMode = chunkedMode || (Build.VERSION.SDK_INT < Build.VERSION_CODES.FROYO);
                     useChunkedMode = useChunkedMode || (fixedLength == -1);
 
                     if (useChunkedMode) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->
### Platforms affected

Android
### What does this PR do?

File uploads over https were automatically turned to Transfer-encoding: chunked due to old Android issues. Since adding this header to transfers often breaks functionality (for example you can't add an additional header to an Amazon S3 request that was signed without it) - isn't it better to follow the users instruction to use chunked mode or not instead of overwriting it? 
### What testing has been done on this change?

Only deployed on one Android device, can not verify that it doesn't cause OOM issues - but this option is available as a setting for the user to controll in js.
### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
