### PR TITLE
CB-12100 (ios) Fixed test plugin install at platform add on cordova@6…

### DIFF
--- a/tests/hooks/after_prepare.js
+++ b/tests/hooks/after_prepare.js
@@ -29,6 +29,7 @@ module.exports = function(context) {
         // get the file transfer server address from the specified variables
         var fileTransferServerAddress = getFileTransferServerAddress(context) || getDefaultFileTransferServerAddress(context);
         console.log('Tests will use the following file transfer server address: ' + fileTransferServerAddress);
+        console.log('If you\'re using cordova@6.3.1 and the above address is wrong at "platform add", don\'t worry, it\'ll fix itself on "cordova run" or "cordova prepare".');
 
         // pass it to the tests
         writeFileTransferOptions(fileTransferServerAddress, context);
@@ -51,7 +52,11 @@ module.exports = function(context) {
         var platformJsonFile = path.join(context.opts.projectRoot, 'platforms', context.opts.platforms[0], context.opts.platforms[0] + '.json');
         var platformJson = JSON.parse(fs.readFileSync(platformJsonFile, 'utf8'));
 
-        return platformJson.installed_plugins['cordova-plugin-file-transfer-tests'].FILETRANSFER_SERVER_ADDRESS;
+        if (platformJson && platformJson.installed_plugins && platformJson.installed_plugins['cordova-plugin-file-transfer-tests'] && platformJson.installed_plugins['cordova-plugin-file-transfer-tests'].FILETRANSFER_SERVER_ADDRESS) {
+            return platformJson.installed_plugins['cordova-plugin-file-transfer-tests'].FILETRANSFER_SERVER_ADDRESS;
+        } else {
+            return null;
+        }
     }
 
     function writeFileTransferOptions(address, context) {


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Fixes the problem described here: https://issues.apache.org/jira/browse/CB-12100
"cordova platform add ios" would fail on cordova@6.3.1 when "file transfer tests" plugin is added to the project.

### What testing has been done on this change?
Manual platform rm/add and paramedic run for iOS with cordova@6.3.1 as well as with cordova@6.4.0

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change - this is already being tested via [this Jenkins job](http://cordova-ci.cloudapp.net:8080/job/cordova-plugin-file-transfer-toolset/).