### PR TITLE
CB-10974 Cordova file transfer Content-Length header problem

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -430,7 +430,7 @@ public class FileTransfer extends CordovaPlugin {
                     // setFixedLengthStreamingMode causes and OutOfMemoryException on pre-Froyo devices.
                     // http://code.google.com/p/android/issues/detail?id=3164
                     // It also causes OOM if HTTPS is used, even on newer devices.
-                    boolean useChunkedMode = chunkedMode || (Build.VERSION.SDK_INT < Build.VERSION_CODES.FROYO || useHttps);
+                    boolean useChunkedMode = chunkedMode || (Build.VERSION.SDK_INT < Build.VERSION_CODES.FROYO);
                     useChunkedMode = useChunkedMode || (fixedLength == -1);
 
                     if (useChunkedMode) {
@@ -440,6 +440,10 @@ public class FileTransfer extends CordovaPlugin {
                         conn.setRequestProperty("Transfer-Encoding", "chunked");
                     } else {
                         conn.setFixedLengthStreamingMode(fixedLength);
+
+                        if (useHttps) {
+                            LOG.w(LOG_TAG, "setFixedLengthStreamingMode could cause OutOfMemoryException - switch to chunkedMode=true to avoid it if this is an issue.");
+                        }
                     }
 
                     conn.connect();
@@ -564,7 +568,6 @@ public class FileTransfer extends CordovaPlugin {
                     }
 
                     if (conn != null) {
-                        // Revert back to the proper verifier and socket factories
                         // Revert back to the proper verifier and socket factories
                         if (trustEveryone && useHttps) {
                             HttpsURLConnection https = (HttpsURLConnection) conn;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Don't force chunkedMode=true for HTTPS if it was specified as false in the UploadOptions (added a warning about possible OOM for chunkedMode=false+HTTPS case)

### What testing has been done on this change?
Manual and auto tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
