### PR TITLE
CB-12154 file-transfer progressEvent.total = -1 on iOS

### DIFF
--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -229,6 +229,8 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
         totalPayloadLength += [postBodyBeforeFile length] + [postBodyAfterFile length];
     }
 
+    [req setValue:[[NSNumber numberWithLongLong:totalPayloadLength] stringValue] forHTTPHeaderField:@"Content-Length"];
+
     if (chunkedMode) {
         CFReadStreamRef readStream = NULL;
         CFWriteStreamRef writeStream = NULL;
@@ -266,7 +268,6 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
             CFRelease(writeStream);
         }];
     } else {
-        [req setValue:[[NSNumber numberWithLongLong:totalPayloadLength] stringValue] forHTTPHeaderField:@"Content-Length"];
         if (multipartFormUpload) {
             [postBodyBeforeFile appendData:fileData];
             [postBodyBeforeFile appendData:postBodyAfterFile];
@@ -814,7 +815,7 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     if (self.direction == CDV_TRANSFER_UPLOAD) {
         NSMutableDictionary* uploadProgress = [NSMutableDictionary dictionaryWithCapacity:3];
 
-        [uploadProgress setObject:[NSNumber numberWithBool:(!self.chunkedMode)] forKey:@"lengthComputable"];
+        [uploadProgress setObject:[NSNumber numberWithBool:true] forKey:@"lengthComputable"];
         [uploadProgress setObject:[NSNumber numberWithLongLong:totalBytesWritten] forKey:@"loaded"];
         [uploadProgress setObject:[NSNumber numberWithLongLong:totalBytesExpectedToWrite] forKey:@"total"];
         CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:uploadProgress];

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1506,7 +1506,9 @@ exports.defineAutoTests = function () {
                             obj = JSON.parse(uploadResult.response);
 
                             if (specContext.uploadOptions.chunkedMode) {
-                                expect(obj["content-length"]).not.toBeDefined("Expected Content-Length not to be defined");
+                                if (!isIos) {
+                                    expect(obj["content-length"]).not.toBeDefined("Expected Content-Length not to be defined");
+                                }
                                 expect(obj["transfer-encoding"].toLowerCase()).toEqual("chunked");
                             } else {
                                 expect(obj["content-length"]).toBeDefined("Expected Content-Length to be defined");


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Reverts logic for not setting `Content-Length` for `chunkedMode=true`.
This was causing progress events total to be -1 and progress to be not computable.
So while this change technically violates the [specification](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4) it fixes the functionality.

### What testing has been done on this change?
Manual and autotests.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

