### PR TITLE
CB-12353 Corrected merges usage in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -139,14 +139,14 @@
     <!-- windows8 -->
     <platform name="windows8">
         <js-module src="src/windows/FileTransferProxy.js" name="FileTransferProxy">
-            <clobbers target="" />
+            <runs />
         </js-module>
     </platform>
 
     <!-- windows -->
     <platform name="windows">
         <js-module src="src/windows/FileTransferProxy.js" name="FileTransferProxy">
-            <clobbers target="" />
+            <runs />
         </js-module>
     </platform>
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Use `runs` instead of `merges` to prevent proxy overriding by another plugin (see details in the [Jira issue](https://issues.apache.org/jira/browse/CB-12353))

### What testing has been done on this change?
Run auto and manual tests

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
