### PR TITLE
CB-12399: (Android) Fix bug with WebView & CookieManager cookies

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -236,7 +236,6 @@ public class FileTransfer extends CordovaPlugin {
     }
 
     private String getCookies(final String target) {
-        boolean gotCookie = false;
         String cookie = null;
         Class webViewClass = webView.getClass();
         try {
@@ -249,15 +248,19 @@ public class FileTransfer extends CordovaPlugin {
                             gcmMethod.invoke(webView)
                         ), target);
 
-            gotCookie = true;
         } catch (NoSuchMethodException e) {
         } catch (IllegalAccessException e) {
         } catch (InvocationTargetException e) {
         } catch (ClassCastException e) {
         }
 
-        if (!gotCookie && CookieManager.getInstance() != null) {
-            cookie = CookieManager.getInstance().getCookie(target);
+        if (CookieManager.getInstance() != null) {
+            String cmCookie = CookieManager.getInstance().getCookie(target);
+            if (cookie != null) {
+                cookie += "; " + cmCookie;
+            } else {
+                cookie = cmCookie;
+            }
         }
 
         return cookie;


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Resolves the issue where only WebView cookies would be used, affecting hybrid applications which use CookieManager cookies.

### What testing has been done on this change?
Tested on Motorola, Nexus 6, and Pixel devices.
Also tested on various emulators api ranges (19 - 24).

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
