### PR TITLE
fix Chinese words error in filename

### DIFF
--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -439,6 +439,8 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
         target = [target stringByReplacingOccurrencesOfString:@"//" withString:@"/"];
         targetURL = [[self.commandDelegate getCommandInstance:@"File"] fileSystemURLforLocalPath:target].url;
     } else {
+        // fix Chinese words
+        target = [target stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
         targetURL = [NSURL URLWithString:target];
     }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?


### What testing has been done on this change?
download a picture file and save it with Chinese word filename on iOS emulator

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
