### PR TITLE
CB-12745: Adding support for non base64 encoded data-URIs

### DIFF
--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -191,7 +191,13 @@ exec(win, fail, 'FileTransfer', 'upload',
             return;
         }
 
-        if (filePath.indexOf("data:") === 0 && filePath.indexOf("base64") !== -1) {
+        if (filePath.indexOf("data:") === 0) {
+            // check if we have base64 encoded data
+            var isBase64 = false;
+            if (filePath.indexOf("base64") !== -1) {
+                isBase64 = true;
+            }
+
             // First a DataWriter object is created, backed by an in-memory stream where 
             // the data will be stored.
             var writer = Windows.Storage.Streams.DataWriter(new Windows.Storage.Streams.InMemoryRandomAccessStream());
@@ -241,10 +247,18 @@ exec(win, fail, 'FileTransfer', 'upload',
                 uploader.setRequestHeader("Content-Type", "multipart/form-data; boundary=" + BOUNDARY);
                 writer.writeString(multipartParams);
                 writer.writeString(multipartFile);
-                writer.writeBytes(stringToByteArray(fileDataString));
+                if (isBase64) {
+                    writer.writeBytes(stringToByteArray(fileDataString));
+                } else {
+                    writer.writeString(decodeURIComponent(fileDataString));
+                }
                 writer.writeString(bound);
             } else {
-                writer.writeBytes(stringToByteArray(fileDataString));
+                if (isBase64) {
+                    writer.writeBytes(stringToByteArray(fileDataString));
+                } else {
+                    writer.writeString(decodeURIComponent(fileDataString));
+                }
             }
 
             var stream;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS, windows

### What does this PR do?
Adding support for non base64 encoded data-URIs

### What testing has been done on this change?
Tested on iOS Simulator and real App
Tested on Windows 10 machine

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change. (no test changes required)
