### PR TITLE
CB-7995: document that `FileTransferError.exception` on iOS is never used

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ A `FileTransferError` object is passed to an error callback when an error occurs
 
 - __exception__: Either e.getMessage or e.toString (String)
 
+### iOS Quirks
+
+__exception__ is never defined.
+
 ### Constants
 
 - 1 = `FileTransferError.FILE_NOT_FOUND_ERR`


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-7995

