### PR TITLE
CB-13294 Remove cordova-plugin-compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file-transfer",
-  "version": "1.6.4-dev",
+  "version": "2.0.0-dev",
   "description": "Cordova File Transfer Plugin",
   "types": "./types/index.d.ts",
   "cordova": {
@@ -53,7 +53,7 @@
   "engines": {
     "cordovaDependencies": {
       "2.0.0": {
-        "cordova": ">100"
+        "cordova-android": ">=6.3.0"
       }
     }
   },

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-file-transfer"
-    version="1.6.4-dev">
+    version="2.0.0-dev">
     <name>File Transfer</name>
     <description>Cordova File Transfer Plugin</description>
     <license>Apache 2.0</license>
@@ -29,7 +29,9 @@
     <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-file-transfer.git</repo>
     <issue>https://issues.apache.org/jira/browse/CB/component/12320650</issue>
 
-    <dependency id="cordova-plugin-file" version="^4.0.0" />
+    <engines>
+        <engine name="cordova-android" version=">=6.3.0" />
+    </engines>
 
     <js-module src="www/FileTransferError.js" name="FileTransferError">
         <clobbers target="window.FileTransferError" />


### PR DESCRIPTION
### Platforms affected
cordova-android@6.3.0

### What does this PR do?
Removes the dependency on cordova-plugin-compat, and includes checks for min platform version.

### What testing has been done on this change?
Testing 1:
- Add local plugin to project containing cordova-android@6.3.0
- Verify plugin installs, and app runs.

Testing 2:
- Add local plugin to project containing cordova-android@6.2.3
- Verify plugin does not install.
- Console log as follows:

```
Plugin doesn't support this project's cordova-android version. cordova-android: 6.2.3, failed version requirement: >=6.3.0
Skipping 'cordova-plugin-file-transfer' for android
```

This is desirable - this change stops the plugin being installed on `<cordova-android@6.3.0`

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.