### PR TITLE
CB-12551: (android) Patch Security Provider to support TLS 1.2

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -54,6 +54,8 @@
         <source-file src="src/android/FileTransfer.java" target-dir="src/org/apache/cordova/filetransfer" />
         <source-file src="src/android/FileProgressResult.java" target-dir="src/org/apache/cordova/filetransfer" />
         <source-file src="src/android/FileUploadResult.java" target-dir="src/org/apache/cordova/filetransfer" />
+
+        <framework src="com.google.android.gms:play-services-base:15.0.0+" />
     </platform>
 
     <!-- amamzon-fireos -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -39,6 +39,11 @@
         <clobbers target="window.FileTransfer" />
     </js-module>
 
+    <engines>
+        <engine name="cordova" version=">=7.1.0"/>
+        <engine name="cordova-android" version=">=6.3.0"/>
+    </engines>
+
     <!-- android -->
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">
@@ -55,7 +60,8 @@
         <source-file src="src/android/FileProgressResult.java" target-dir="src/org/apache/cordova/filetransfer" />
         <source-file src="src/android/FileUploadResult.java" target-dir="src/org/apache/cordova/filetransfer" />
 
-        <framework src="com.google.android.gms:play-services-base:15.0.0+" />
+        <preference name="PLAY_SERVICES_VERSION" default="15.0.0+"/>
+        <framework src="com.google.android.gms:play-services-base:$PLAY_SERVICES_VERSION" />
     </platform>
 
     <!-- amamzon-fireos -->

--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -53,7 +53,12 @@ import org.json.JSONObject;
 
 import android.net.Uri;
 import android.os.Build;
+import android.util.Log;
 import android.webkit.CookieManager;
+
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
+import com.google.android.gms.common.GooglePlayServicesRepairableException;
+import com.google.android.gms.security.ProviderInstaller;
 
 public class FileTransfer extends CordovaPlugin {
 
@@ -167,6 +172,17 @@ public class FileTransfer extends CordovaPlugin {
         if (action.equals("upload") || action.equals("download")) {
             String source = args.getString(0);
             String target = args.getString(1);
+
+            // Patch the Security Provider via Google Play Services to improve support for newer TLS/SSL standards in
+            // older versions of Android (@jira:CB-12551). More info here:
+            // https://developer.android.com/training/articles/security-gms-provider.html
+            try {
+                ProviderInstaller.installIfNeeded(this.cordova.getActivity().getApplicationContext());
+            } catch (GooglePlayServicesRepairableException e) {
+                Log.e(LOG_TAG, "Google Play Services is out of date. Unable to patch security provider");
+            } catch (GooglePlayServicesNotAvailableException e) {
+                Log.e(LOG_TAG, "Unable to patch security provider");
+            }
 
             if (action.equals("upload")) {
                 upload(source, target, args, callbackContext);

--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -53,9 +53,10 @@ import org.json.JSONObject;
 
 import android.net.Uri;
 import android.os.Build;
-import android.util.Log;
+import org.apache.cordova.LOG;
 import android.webkit.CookieManager;
 
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
 import com.google.android.gms.security.ProviderInstaller;
@@ -179,9 +180,14 @@ public class FileTransfer extends CordovaPlugin {
             try {
                 ProviderInstaller.installIfNeeded(this.cordova.getActivity().getApplicationContext());
             } catch (GooglePlayServicesRepairableException e) {
-                Log.e(LOG_TAG, "Google Play Services is out of date. Unable to patch security provider");
+                LOG.e(LOG_TAG, "Google Play Services is out of date. Unable to patch security provider");
+
+                // Prompt the user to install/update/enable Google Play services.
+                GoogleApiAvailability.getInstance()
+                        .showErrorNotification(this.cordova.getActivity().getApplicationContext(),
+                                e.getConnectionStatusCode());
             } catch (GooglePlayServicesNotAvailableException e) {
-                Log.e(LOG_TAG, "Unable to patch security provider");
+                LOG.e(LOG_TAG, "Unable to patch security provider");
             }
 
             if (action.equals("upload")) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android 4.4 and below (API level 16-20)

### What does this PR do?

Adds support for newer versions of TLS (v1.2) to older versions of Android (API level 16+) by patching the Security Provider with ProviderInstaller as per the documentation here: https://developer.android.com/training/articles/security-gms-provider.html

### What testing has been done on this change?

I've only been able to test Android 4.4.x, but this should work on Android API levels 16+.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
    - Issue already exists: https://issues.apache.org/jira/browse/CB-12551
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
    - N/A
