### PR TITLE
[windows] Fix js error 'The parameter is incorrect' for upload

### DIFF
--- a/src/windows/FileTransferProxy.js
+++ b/src/windows/FileTransferProxy.js
@@ -110,6 +110,10 @@ function doUpload (upload, uploadId, filePath, server, successCallback, errorCal
                     if (!response) {
                         resolve(new FTErr(FTErr.CONNECTION_ERR, source, server));
                     } else {
+                        if (upload.progress.bytesReceived === 0) {
+                            resolve(new FTErr(FTErr.FILE_NOT_FOUND_ERR, source, server, response.statusCode, null, error));
+                            return;
+                        }
                         var reader = new Windows.Storage.Streams.DataReader(upload.getResultStreamAt(0));
                         reader.loadAsync(upload.progress.bytesReceived).then(function (size) {
                             var responseText = reader.readString(size);


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Windows

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

There was a similar PR recenly - https://github.com/apache/cordova-plugin-file-transfer/pull/199 - that fixed this error for Windows on the download portion of the code.  
I was testing this plugin, trying to upload files, and our directory was set as read only to test failing the download.  An unhandled exception would be thrown and crash our Windows app.  This is a catch for that exception.  

### Description
<!-- Describe your changes in detail -->

When upload.progress.bytesReceived is 0, this fix will catch that case very similar to the download fix, and resolve an error and stop the function.  

### Testing
<!-- Please describe in detail how you tested your changes. -->

Manual testing - Loaded our app with my changed version of the plugin installed.  The download still failed, as intended to a read only directory, but the app did not crash, and our file upload call was able to receive the 500 error.  

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
