### PR TITLE
(ios)Remove UIWebView useragent for cordova-ios@6.x.x

### DIFF
--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -104,11 +104,6 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
 {
     [req setValue:@"XMLHttpRequest" forHTTPHeaderField:@"X-Requested-With"];
 
-    NSString* userAgent = [self.commandDelegate userAgent];
-    if (userAgent) {
-        [req setValue:userAgent forHTTPHeaderField:@"User-Agent"];
-    }
-
     for (NSString* headerName in headers) {
         id value = [headers objectForKey:headerName];
         if (!value || (value == [NSNull null])) {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
Will not build on cordova-ios@6.x.x due to deprecated method



### Description
Removes a method not available anymore


### Testing
No testing required

### Checklist

- [v] I've run the tests to see all new and existing tests pass
- [v] I added automated test coverage as appropriate for this change
- [v] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [v] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [v] I've updated the documentation if necessary
