### PR TITLE
fix(ios): re-implement user agent overwrite

### DIFF
--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -103,36 +103,34 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
 - (void)applyRequestHeaders:(NSDictionary*)headers toRequest:(NSMutableURLRequest*)req
 {
     [req setValue:@"XMLHttpRequest" forHTTPHeaderField:@"X-Requested-With"];
-
-    NSString* userAgent = [self.commandDelegate userAgent];
-    if (userAgent) {
+    [self.webViewEngine evaluateJavaScript:@"navigator.userAgent" completionHandler:^(NSString* userAgent, NSError* error) {
         [req setValue:userAgent forHTTPHeaderField:@"User-Agent"];
-    }
 
-    for (NSString* headerName in headers) {
-        id value = [headers objectForKey:headerName];
-        if (!value || (value == [NSNull null])) {
-            value = @"null";
-        }
-
-        // First, remove an existing header if one exists.
-        [req setValue:nil forHTTPHeaderField:headerName];
-
-        if (![value isKindOfClass:[NSArray class]]) {
-            value = [NSArray arrayWithObject:value];
-        }
-
-        // Then, append all header values.
-        for (id __strong subValue in value) {
-            // Convert from an NSNumber -> NSString.
-            if ([subValue respondsToSelector:@selector(stringValue)]) {
-                subValue = [subValue stringValue];
+        for (NSString* headerName in headers) {
+            id value = [headers objectForKey:headerName];
+            if (!value || (value == [NSNull null])) {
+                value = @"null";
             }
-            if ([subValue isKindOfClass:[NSString class]]) {
-                [req addValue:subValue forHTTPHeaderField:headerName];
+            
+            // First, remove an existing header if one exists.
+            [req setValue:nil forHTTPHeaderField:headerName];
+            
+            if (![value isKindOfClass:[NSArray class]]) {
+                value = [NSArray arrayWithObject:value];
+            }
+            
+            // Then, append all header values.
+            for (id __strong subValue in value) {
+                // Convert from an NSNumber -> NSString.
+                if ([subValue respondsToSelector:@selector(stringValue)]) {
+                    subValue = [subValue stringValue];
+                }
+                if ([subValue isKindOfClass:[NSString class]]) {
+                    [req addValue:subValue forHTTPHeaderField:headerName];
+                }
             }
         }
-    }
+    }];
 }
 
 - (NSURLRequest*)requestForUploadCommand:(CDVInvokedUrlCommand*)command fileData:(NSData*)fileData


### PR DESCRIPTION
This closes #263
This closes #258

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context

This solves the issue in #258 and makes the plugin compatible with cordova-ios@6.  
It also re-implements the user agent overwrite.

### Description

Sadly, there is no "nice" way to obtain the WKWebView user agent other than evaluating JavaScript.

### Testing

My local fork compiles and has the correct user agent attached when making the network requests.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
