### PR TITLE
fix(ios): headers are not being sent

### DIFF
--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -103,34 +103,31 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
 - (void)applyRequestHeaders:(NSDictionary*)headers toRequest:(NSMutableURLRequest*)req
 {
     [req setValue:@"XMLHttpRequest" forHTTPHeaderField:@"X-Requested-With"];
-    [self.webViewEngine evaluateJavaScript:@"navigator.userAgent" completionHandler:^(NSString* userAgent, NSError* error) {
-        [req setValue:userAgent forHTTPHeaderField:@"User-Agent"];
 
-        for (NSString* headerName in headers) {
-            id value = [headers objectForKey:headerName];
-            if (!value || (value == [NSNull null])) {
-                value = @"null";
+    for (NSString* headerName in headers) {
+        id value = [headers objectForKey:headerName];
+        if (!value || (value == [NSNull null])) {
+            value = @"null";
+        }
+
+        // First, remove an existing header if one exists.
+        [req setValue:nil forHTTPHeaderField:headerName];
+
+        if (![value isKindOfClass:[NSArray class]]) {
+            value = [NSArray arrayWithObject:value];
+        }
+
+        // Then, append all header values.
+        for (id __strong subValue in value) {
+            // Convert from an NSNumber -> NSString.
+            if ([subValue respondsToSelector:@selector(stringValue)]) {
+                subValue = [subValue stringValue];
             }
-            
-            // First, remove an existing header if one exists.
-            [req setValue:nil forHTTPHeaderField:headerName];
-            
-            if (![value isKindOfClass:[NSArray class]]) {
-                value = [NSArray arrayWithObject:value];
-            }
-            
-            // Then, append all header values.
-            for (id __strong subValue in value) {
-                // Convert from an NSNumber -> NSString.
-                if ([subValue respondsToSelector:@selector(stringValue)]) {
-                    subValue = [subValue stringValue];
-                }
-                if ([subValue isKindOfClass:[NSString class]]) {
-                    [req addValue:subValue forHTTPHeaderField:headerName];
-                }
+            if ([subValue isKindOfClass:[NSString class]]) {
+                [req addValue:subValue forHTTPHeaderField:headerName];
             }
         }
-    }];
+    }
 }
 
 - (NSURLRequest*)requestForUploadCommand:(CDVInvokedUrlCommand*)command fileData:(NSData*)fileData


### PR DESCRIPTION
### Platforms affected
iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The call to evaluateJavaScript is not blocking resulting in the headers
being set on the request after it is already sent.

fixes #285


### Description
<!-- Describe your changes in detail -->
Both the android and windows native code do not set the user-agent header.
The user can still set the user-agent header by sending it from javascript.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I've changed these lines in our application because our FileTransfer uses a `Authorization` header that was not being sent anymore.
After this change the request succeeds again.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
