### PR TITLE
fix(ios): remove hardcoded X-Requested-With header

### DIFF
--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -102,8 +102,6 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
 
 - (void)applyRequestHeaders:(NSDictionary*)headers toRequest:(NSMutableURLRequest*)req
 {
-    [req setValue:@"XMLHttpRequest" forHTTPHeaderField:@"X-Requested-With"];
-
     for (NSString* headerName in headers) {
         id value = [headers objectForKey:headerName];
         if (!value || (value == [NSNull null])) {


### PR DESCRIPTION
no other platform sets this header and it should be up to the user if it's desired to 'disguise' the HTTP call as an XMLHttpRequest

