### PR TITLE
feat!: remove deprecated whitelist usage

### DIFF
--- a/src/android/FileTransfer.java
+++ b/src/android/FileTransfer.java
@@ -45,7 +45,6 @@ import org.apache.cordova.CordovaResourceApi.OpenForReadResult;
 import org.apache.cordova.LOG;
 import org.apache.cordova.PluginManager;
 import org.apache.cordova.PluginResult;
-import org.apache.cordova.Whitelist;
 import org.apache.cordova.file.FileUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -676,25 +675,11 @@ public class FileTransfer extends CordovaPlugin {
             return;
         }
 
-        /* This code exists for compatibility between 3.x and 4.x versions of Cordova.
-         * Previously the CordovaWebView class had a method, getWhitelist, which would
-         * return a Whitelist object. Since the fixed whitelist is removed in Cordova 4.x,
-         * the correct call now is to shouldAllowRequest from the plugin manager.
-         */
         Boolean shouldAllowRequest = null;
         if (isLocalTransfer) {
             shouldAllowRequest = true;
         }
-        if (shouldAllowRequest == null) {
-            try {
-                Method gwl = webView.getClass().getMethod("getWhitelist");
-                Whitelist whitelist = (Whitelist)gwl.invoke(webView);
-                shouldAllowRequest = whitelist.isUrlWhiteListed(source);
-            } catch (NoSuchMethodException e) {
-            } catch (IllegalAccessException e) {
-            } catch (InvocationTargetException e) {
-            }
-        }
+
         if (shouldAllowRequest == null) {
             try {
                 Method gpm = webView.getClass().getMethod("getPluginManager");
@@ -708,12 +693,11 @@ public class FileTransfer extends CordovaPlugin {
         }
 
         if (!Boolean.TRUE.equals(shouldAllowRequest)) {
-            LOG.w(LOG_TAG, "Source URL is not in white list: '" + source + "'");
+            LOG.w(LOG_TAG, "The Source URL is not in the Allow List: '" + source + "'");
             JSONObject error = createFileTransferError(CONNECTION_ERR, source, target, null, 401, null);
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.IO_EXCEPTION, error));
             return;
         }
-
 
         final RequestContext context = new RequestContext(source, target, callbackContext);
         synchronized (activeRequests) {


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context

Build is failing in Cordova-Android 10.

fixes: #306

### Description

The `Whitelist` import can be removed.

The `getWhitelist` method was removed a long time ago. The `getWhitelist` method was related to the commented statement:

> This code exists for compatibility between 3.x and 4.x versions of Cordova.

The `AllowList` which was integrated into the core of **cordova-android** is still being loaded as if it was a plugin so there for the next if block should still work as usual to fetch the `shouldAllowRequest` value.

```java
if (shouldAllowRequest == null) {
    try {
        Method gpm = webView.getClass().getMethod("getPluginManager");
        PluginManager pm = (PluginManager)gpm.invoke(webView);
        Method san = pm.getClass().getMethod("shouldAllowRequest", String.class);
        shouldAllowRequest = (Boolean)san.invoke(pm, source);
    } catch (NoSuchMethodException e) {
    } catch (IllegalAccessException e) {
    } catch (InvocationTargetException e) {
    }
}
```

Additionally, since there hasn't been a release since the undeprecation, it should be safe to say that the next release will be major and removing this old code is acceptable.

### Testing

- `cordova build`: build now passes

If anyone wants to confirm the `shouldAllowRequest` functionality continues to work as expected with their app, that would be appreciated.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
