### PR TITLE
feat(android)!: bump cordova-plugin-file@8.0.0 & cordova-android >= 12.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
       },
       "engines": {
         "cordovaDependencies": {
+          "2.0.0": {
+            "cordova-android": ">=12.0.0"
+          },
           "3.0.0": {
             "cordova": ">100"
           }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "license": "Apache-2.0",
   "engines": {
     "cordovaDependencies": {
+      "2.0.0": {
+        "cordova-android": ">=12.0.0"
+      },
       "3.0.0": {
         "cordova": ">100"
       }

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,11 @@
     <repo>https://github.com/apache/cordova-plugin-file-transfer</repo>
     <issue>https://github.com/apache/cordova-plugin-file-transfer/issues</issue>
 
-    <dependency id="cordova-plugin-file" version=">=7.0.0" />
+    <engines>
+        <engine name="cordova-android" version=">=12.0.0" />
+    </engines>
+
+    <dependency id="cordova-plugin-file" version="^8.0.0" />
 
     <js-module src="www/FileTransferError.js" name="FileTransferError">
         <clobbers target="window.FileTransferError" />

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file-transfer-tests",
-  "version": "1.6.3-dev",
+  "version": "2.0.0-dev",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-file-transfer-tests",

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file-transfer-tests",
-  "version": "2.0.0-dev",
+  "version": "1.6.3-dev",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-file-transfer-tests",


### PR DESCRIPTION
### Platforms affected

android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Use latest file plugin which resolves permission issues in Android 13+ (SDK 33) 

### Description
<!-- Describe your changes in detail -->

* Bump file plugin version to 8.0.0
* Added Cordova-Android requirement to >=12.0.0 which supports SDK 33.

### Testing
<!-- Please describe in detail how you tested your changes. -->

`npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
