### PR TITLE
fix(tests): change default server port

### DIFF
--- a/tests/server/index.js
+++ b/tests/server/index.js
@@ -3,7 +3,7 @@ const stringify = require('json-stringify-safe');
 const Busboy = require('busboy');
 const { Iconv } = require('iconv');
 
-const port = process.env.PORT || 5000;
+const port = process.env.PORT || 5001;
 const DIRECT_UPLOAD_LIMIT = 85; // bytes
 
 // convert from UTF-8 to ISO-8859-1


### PR DESCRIPTION
port 5000 is taken by default on macOS monterrey and newer, use 5001

see https://github.com/apache/cordova-paramedic/pull/262

