### PR TITLE
Fix for iOS with cordova-plugin-file >=8.1.3

### DIFF
--- a/www/FileTransfer.js
+++ b/www/FileTransfer.js
@@ -75,6 +75,16 @@ const FileTransfer = function () {
     this.onprogress = null; // optional callback
 };
 
+const iOSPathFix = function (path) {
+    if (window.CDV_ASSETS_URL) {
+        const pathstart = window.CDV_ASSETS_URL + '/_app_file_';
+        if (path.startsWith(pathstart)) {
+            return 'file://' + path.substring(pathstart.length);
+        }
+    }
+    return path;
+};
+
 /**
  * Given an absolute file path, uploads a file on the device to a remote server
  * using a multipart HTTP request.
@@ -87,6 +97,9 @@ const FileTransfer = function () {
  */
 FileTransfer.prototype.upload = function (filePath, server, successCallback, errorCallback, options, trustAllHosts) {
     argscheck.checkArgs('ssFFO*', 'FileTransfer.upload', arguments);
+
+    filePath = iOSPathFix(filePath);
+
     // check for options
     let fileKey = null;
     let fileName = null;
@@ -171,6 +184,8 @@ FileTransfer.prototype.upload = function (filePath, server, successCallback, err
 FileTransfer.prototype.download = function (source, target, successCallback, errorCallback, trustAllHosts, options) {
     argscheck.checkArgs('ssFF*', 'FileTransfer.download', arguments);
     const self = this;
+
+    target = iOSPathFix(target);
 
     const basicAuthHeader = getBasicAuthHeader(source);
     if (basicAuthHeader) {


### PR DESCRIPTION


<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Since cordova-plugin-file 8.1.3, on iOS, urls returned by `Entry.toURL()` are not anymore in `'file://'` format, but in `window.CDV_ASSETS_URL + '/_app_file_'` format (where `window.CDV_ASSETS_URL = scheme + '://' + hostname`, and these values are defined in config.xml)


### Description
<!-- Describe your changes in detail -->

I added a function that returns the `'file://'` url if the url starts with `window.CDV_ASSETS_URL + '/_app_file_'`. Then I used it to filter the `filePath` and `target` values

I'm not sure if it is the best solution, but it works for me.

### Testing
<!-- Please describe in detail how you tested your changes. -->

We have an app that had no issues with cordova-plugin-file <8.1.3 and cordova-plugin-file-transfer.

After an upgrade to cordova-plugin-file 8.1.3, we noticed file downloads with cordova-plugin-file-transfer was not working.

With this change to cordova-plugin-file-transfer, downloads are working again. As the additional function does nothing if the url does not start with `window.CDV_ASSETS_URL + '/_app_file_'`, it should have no side effects

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
