### PR TITLE
fix(ios): cast to `CDVFile` when getting the plugin by `getCommandInstance`

### DIFF
--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -20,6 +20,7 @@
 #import <Cordova/CDV.h>
 #import "CDVFileTransfer.h"
 #import "CDVLocalFilesystem.h"
+#import "CDVFile.h"
 
 #import <AssetsLibrary/ALAsset.h>
 #import <AssetsLibrary/ALAssetRepresentation.h>
@@ -289,7 +290,7 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     delegate.source = source;
     delegate.target = server;
     delegate.trustAllHosts = trustAllHosts;
-    delegate.filePlugin = [self.commandDelegate getCommandInstance:@"File"];
+    delegate.filePlugin = (CDVFile *)[self.commandDelegate getCommandInstance:@"File"];
     delegate.chunkedMode = chunkedMode;
 
     return delegate;
@@ -328,7 +329,8 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     if (sourceURL) {
         // Try to get a CDVFileSystem which will handle this file.
         // This requires talking to the current CDVFile plugin.
-        fs = [[self.commandDelegate getCommandInstance:@"File"] filesystemForURL:sourceURL];
+        CDVFile *filePlugin = (CDVFile *)[self.commandDelegate getCommandInstance:@"File"];
+        fs = [filePlugin filesystemForURL:sourceURL];
     }
     if (fs) {
         __weak CDVFileTransfer* weakSelf = self;
@@ -430,7 +432,8 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
          * Check here to see if it looks like the user passed in a raw filesystem path. (Perhaps they had the path saved, and were previously using it with the old version of File). If so, normalize it by removing empty path segments, and check with File to see if any of the installed filesystems will handle it. If so, then we will end up with a filesystem url to use for the remainder of this operation.
          */
         target = [target stringByReplacingOccurrencesOfString:@"//" withString:@"/"];
-        targetURL = [[self.commandDelegate getCommandInstance:@"File"] fileSystemURLforLocalPath:target].url;
+        CDVFile *filePlugin = (CDVFile *)[self.commandDelegate getCommandInstance:@"File"];
+        targetURL = [filePlugin fileSystemURLforLocalPath:target].url;
     } else {
         targetURL = [NSURL URLWithString:target];
 
@@ -476,7 +479,7 @@ static CFIndex WriteDataToStream(NSData* data, CFWriteStreamRef stream)
     delegate.target = [targetURL absoluteString];
     delegate.targetURL = targetURL;
     delegate.trustAllHosts = trustAllHosts;
-    delegate.filePlugin = [self.commandDelegate getCommandInstance:@"File"];
+    delegate.filePlugin = (CDVFile *)[self.commandDelegate getCommandInstance:@"File"];
     delegate.backgroundTaskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
         [delegate cancelTransfer:delegate.connection];
     }];

--- a/src/ios/CDVFileTransfer.m
+++ b/src/ios/CDVFileTransfer.m
@@ -20,7 +20,6 @@
 #import <Cordova/CDV.h>
 #import "CDVFileTransfer.h"
 #import "CDVLocalFilesystem.h"
-#import "CDVFile.h"
 
 #import <AssetsLibrary/ALAsset.h>
 #import <AssetsLibrary/ALAssetRepresentation.h>


### PR DESCRIPTION
- `CDVCommandDelegate getCommandInstance` returns a `CDVPlugin` which does not know about the selectors of an inherited class like `CDVFile`. If not casted, XCode will throw an error like `error: no visible @interface for 'CDVPlugin' declares the selector 'filesystemForURL:'`.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
