### PR TITLE
fix(ios): Set minimum XCode version in GitHub Action to 15

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -50,13 +50,13 @@ jobs:
     strategy:
       matrix:
         versions:
-          - os-version: macos-12
+          - os-version: macos-14
             ios-version: 15.x
-            xcode-version: 13.x
+            xcode-version: 15.x
 
           - os-version: macos-14
             ios-version: 16.x
-            xcode-version: 14.x
+            xcode-version: 15.x
 
           - os-version: macos-14
             ios-version: 17.x


### PR DESCRIPTION
- The iOS 16.x Test failed, because the XCode version 14.x could not be found. A minimum XCode version would be 15.x.
- Made ios-version 15.x test equal with with the other tests. There is no need to run an older xcode version on an older macos version. Event the recent XCode version 26 does support iOS 15, so it's ok to use minimum XCode 15.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
